### PR TITLE
Add support for nested flux executors

### DIFF
--- a/executorlib/__init__.py
+++ b/executorlib/__init__.py
@@ -134,6 +134,7 @@ class Executor:
         init_function: Optional[callable] = None,
         command_line_argument_lst: list[str] = [],
         pmi: Optional[str] = None,
+        nested_flux_executor: bool = False,
         disable_dependencies: bool = False,
         refresh_rate: float = 0.01,
         plot_dependency_graph: bool = False,
@@ -175,6 +176,7 @@ class Executor:
             init_function (None): optional function to preset arguments for functions which are submitted later
             command_line_argument_lst (list): Additional command line arguments for the srun call (SLURM only)
             pmi (str): PMI interface to use (OpenMPI v5 requires pmix) default is None (Flux only)
+            nested_flux_executor (bool): Provide hierarchically nested Flux job scheduler inside the submitted function.
             disable_dependencies (boolean): Disable resolving future objects during the submission.
             refresh_rate (float): Set the refresh rate in seconds, how frequently the input queue is checked.
             plot_dependency_graph (bool): Plot the dependencies of multiple future objects without executing them. For
@@ -199,6 +201,7 @@ class Executor:
                 init_function=init_function,
                 command_line_argument_lst=command_line_argument_lst,
                 pmi=pmi,
+                nested_flux_executor=nested_flux_executor,
                 refresh_rate=refresh_rate,
                 plot_dependency_graph=plot_dependency_graph,
             )
@@ -222,4 +225,5 @@ class Executor:
                 init_function=init_function,
                 command_line_argument_lst=command_line_argument_lst,
                 pmi=pmi,
+                nested_flux_executor=nested_flux_executor,
             )

--- a/executorlib/shared/inputcheck.py
+++ b/executorlib/shared/inputcheck.py
@@ -45,6 +45,13 @@ def check_executor(executor: Executor):
         )
 
 
+def check_nested_flux_executor(nested_flux_executor: bool):
+    if nested_flux_executor:
+        raise ValueError(
+            "The nested_flux_executor parameter is only supported for the flux framework backend."
+        )
+
+
 def check_resource_dict(function: callable):
     if "resource_dict" in inspect.signature(function).parameters.keys():
         raise ValueError(

--- a/tests/test_shared_input_check.py
+++ b/tests/test_shared_input_check.py
@@ -7,6 +7,9 @@ from executorlib.shared.inputcheck import (
     check_oversubscribe,
     check_executor,
     check_init_function,
+    check_nested_flux_executor,
+    check_pmi,
+    check_plot_dependency_graph,
     check_refresh_rate,
     check_resource_dict,
     check_resource_dict_is_empty,
@@ -40,6 +43,18 @@ class TestInputCheck(unittest.TestCase):
             validate_backend(
                 backend="test", flux_installed=False, slurm_installed=False
             )
+        with self.assertRaises(ImportError):
+            validate_backend(
+                backend="flux", flux_installed=False, slurm_installed=False
+            )
+        with self.assertRaises(RuntimeError):
+            validate_backend(
+                backend="slurm", flux_installed=False, slurm_installed=False
+            )
+        self.assertEqual(
+            validate_backend(backend="slurm", flux_installed=False, slurm_installed=True),
+            "slurm",
+        )
 
     def test_check_init_function(self):
         with self.assertRaises(ValueError):
@@ -59,3 +74,17 @@ class TestInputCheck(unittest.TestCase):
     def test_check_resource_dict_is_empty(self):
         with self.assertRaises(ValueError):
             check_resource_dict_is_empty(resource_dict={"a": 1})
+
+    def test_check_pmi(self):
+        with self.assertRaises(ValueError):
+            check_pmi(backend="test", pmi="test")
+        with self.assertRaises(ValueError):
+            check_pmi(backend="flux", pmi="test")
+
+    def test_check_nested_flux_executor(self):
+        with self.assertRaises(ValueError):
+            check_nested_flux_executor(nested_flux_executor=True)
+
+    def test_check_plot_dependency_graph(self):
+        with self.assertRaises(ValueError):
+            check_plot_dependency_graph(plot_dependency_graph=True)

--- a/tests/test_shared_input_check.py
+++ b/tests/test_shared_input_check.py
@@ -52,7 +52,9 @@ class TestInputCheck(unittest.TestCase):
                 backend="slurm", flux_installed=False, slurm_installed=False
             )
         self.assertEqual(
-            validate_backend(backend="slurm", flux_installed=False, slurm_installed=True),
+            validate_backend(
+                backend="slurm", flux_installed=False, slurm_installed=True
+            ),
             "slurm",
         )
 


### PR DESCRIPTION
Previously all tasks were executed by the same `flux` instance, so for the following example code:
```python
import subprocess
import flux.job
from executorlib import Executor


def run_external():
    return subprocess.check_output("flux run -n 2 hostname", shell=True)


with flux.job.FluxExecutor() as flux_exe:
    with Executor(max_cores=2, executor=flux_exe) as exe:
        future = exe.submit(run_external, resource_dict={"threads_per_core": 2})
        print(future.result())
```
This resulted in two tasks in `flux jobs -a`:
```
       JOBID USER     NAME       ST NTASKS NNODES     TIME INFO
    ƒ3jDxMPV janssen  python     CD      1      1   0.874s cmpc06
    ƒ45uLLNT janssen  hostname   CD      2      1   0.028s cmpc06
```
With the new implementation this is represented as a single nested task:
```
       JOBID USER     NAME       ST NTASKS NNODES     TIME INFO
   ƒ4mUoLNbZ janssen  flux       CD      1      1   3.291s cmpc06
```
Still this requires the addition `nested_flux_executor=True` parameter:
```python
import subprocess
import flux.job
from executorlib import Executor


def run_external():
    return subprocess.check_output("flux run -n 2 hostname", shell=True)


with flux.job.FluxExecutor() as flux_exe:
    with Executor(max_cores=2, executor=flux_exe, nested_flux_executor=True) as exe:
        future = exe.submit(run_external, resource_dict={"threads_per_core": 2})
        print(future.result())
```
The reason for this feature being optional is the performance overhead of starting a new flux instance. It seems to be around 2-3 seconds. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Added a `nested_flux_executor` parameter to enhance job scheduling flexibility, allowing for a hierarchically nested Flux job scheduler.
  - Introduced a new function to validate the `nested_flux_executor` parameter for improved error-checking.

- **Documentation**
  - Updated method signatures and docstrings to include details about the new `nested_flux_executor` parameter, ensuring clarity for users.

- **Tests**
  - Enhanced the test suite with new cases validating backend conditions and the behavior of the `check_nested_flux_executor` function.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->