### PR TITLE
Remove h5io from dependencies

### DIFF
--- a/.ci_support/environment-docs.yml
+++ b/.ci_support/environment-docs.yml
@@ -13,4 +13,3 @@ dependencies:
 - flux-core
 - jupyter-book =1.0.0
 - h5py =3.11.0
-- h5io =0.2.4

--- a/.ci_support/environment-mpich.yml
+++ b/.ci_support/environment-mpich.yml
@@ -9,7 +9,6 @@ dependencies:
 - mpi4py =4.0.0
 - pyzmq =26.2.0
 - h5py =3.11.0
-- h5io =0.2.4
 - matplotlib =3.9.2
 - networkx =3.3
 - pygraphviz =1.13

--- a/.ci_support/environment-old.yml
+++ b/.ci_support/environment-old.yml
@@ -9,7 +9,6 @@ dependencies:
 - mpi4py =3.1.4
 - pyzmq =25.0.0
 - h5py =3.6.0
-- h5io =0.2.1
 - matplotlib =3.5.3
 - networkx =2.8.8
 - ipython =7.33.0

--- a/.ci_support/environment-openmpi.yml
+++ b/.ci_support/environment-openmpi.yml
@@ -9,7 +9,6 @@ dependencies:
 - mpi4py =4.0.0
 - pyzmq =26.2.0
 - h5py =3.11.0
-- h5io =0.2.4
 - matplotlib =3.9.2
 - networkx =3.3
 - pygraphviz =1.13

--- a/.ci_support/environment-win.yml
+++ b/.ci_support/environment-win.yml
@@ -9,7 +9,6 @@ dependencies:
 - mpi4py =4.0.0
 - pyzmq =26.2.0
 - h5py =3.11.0
-- h5io =0.2.4
 - matplotlib =3.9.2
 - networkx =3.3
 - pygraphviz =1.13

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -11,4 +11,3 @@ dependencies:
 - flux-pmix =0.5.0
 - versioneer =0.28
 - h5py =3.11.0
-- h5io =0.2.2

--- a/executorlib/cache/hdf.py
+++ b/executorlib/cache/hdf.py
@@ -24,8 +24,9 @@ def dump(file_name: str, data_dict: dict) -> None:
             if data_key in group_dict.keys():
                 fname.create_dataset(
                     name="/" + group_dict[data_key],
-                    data=np.void(cloudpickle.dumps(data_value))
+                    data=np.void(cloudpickle.dumps(data_value)),
                 )
+
 
 def load(file_name: str) -> dict:
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,6 @@ conda = ["conda_subprocess==0.0.4"]
 mpi = ["mpi4py==4.0.0"]
 hdf = [
     "h5py==3.11.0",
-    "h5io==0.2.4",
 ]
 graph = [
     "pygraphviz==1.13",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added specific version constraints for several dependencies, enhancing environment consistency.
  
- **Bug Fixes**
	- Removed the `h5io` dependency from multiple environment configurations to prevent potential conflicts.

- **Documentation**
	- Updated dependency versions in the `pyproject.toml` and various environment files for clarity and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->