### PR TITLE
Update cloudpickle to 3.1.0

### DIFF
--- a/.ci_support/environment-docs.yml
+++ b/.ci_support/environment-docs.yml
@@ -7,7 +7,7 @@ dependencies:
 - myst-parser
 - numpy
 - openmpi
-- cloudpickle =3.0.0
+- cloudpickle =3.1.0
 - mpi4py =4.0.1
 - pyzmq =26.2.0
 - flux-core

--- a/.ci_support/environment-mini.yml
+++ b/.ci_support/environment-mini.yml
@@ -3,5 +3,5 @@ channels:
 dependencies:
 - python
 - numpy
-- cloudpickle =3.0.0
+- cloudpickle =3.1.0
 - pyzmq =26.0.3

--- a/.ci_support/environment-mpich.yml
+++ b/.ci_support/environment-mpich.yml
@@ -4,7 +4,7 @@ dependencies:
 - python
 - numpy
 - mpich
-- cloudpickle =3.0.0
+- cloudpickle =3.1.0
 - mpi4py =4.0.1
 - pyzmq =26.2.0
 - h5py =3.11.0

--- a/.ci_support/environment-openmpi.yml
+++ b/.ci_support/environment-openmpi.yml
@@ -4,7 +4,7 @@ dependencies:
 - python
 - numpy
 - openmpi
-- cloudpickle =3.0.0
+- cloudpickle =3.1.0
 - mpi4py =4.0.1
 - pyzmq =26.2.0
 - h5py =3.11.0

--- a/.ci_support/environment-win.yml
+++ b/.ci_support/environment-win.yml
@@ -4,7 +4,7 @@ dependencies:
 - python
 - numpy
 - msmpi
-- cloudpickle =3.0.0
+- cloudpickle =3.1.0
 - mpi4py =4.0.1
 - pyzmq =26.2.0
 - h5py =3.11.0

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -4,7 +4,7 @@ dependencies:
 - python
 - numpy
 - openmpi
-- cloudpickle =3.0.0
+- cloudpickle =3.1.0
 - mpi4py =3.1.6
 - pyzmq =26.0.0
 - flux-core =0.59.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-    "cloudpickle==3.0.0",
+    "cloudpickle==3.1.0",
     "pyzmq==26.2.0",
 ]
 dynamic = ["version"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the `cloudpickle` dependency to version 3.1.0 for improved performance and compatibility.

- **Bug Fixes**
	- Removed outdated dependencies (`matplotlib`, `networkx`, `pygraphviz`, `ipython`, `flux-pmix`, and `versioneer`) to streamline the environment setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->