### PR TITLE
Move get_command_path() to separate module

### DIFF
--- a/executorlib/shared/cache.py
+++ b/executorlib/shared/cache.py
@@ -10,7 +10,7 @@ from typing import Any, Tuple
 
 import cloudpickle
 
-from executorlib.shared.executor import get_command_path
+from executorlib.shared.command import get_command_path
 from executorlib.shared.hdf import dump, get_output, load
 
 

--- a/executorlib/shared/command.py
+++ b/executorlib/shared/command.py
@@ -1,0 +1,14 @@
+import os
+
+
+def get_command_path(executable: str) -> str:
+    """
+    Get path of the backend executable script
+
+    Args:
+        executable (str): Name of the backend executable script, either mpiexec.py or serial.py
+
+    Returns:
+        str: absolute path to the executable script
+    """
+    return os.path.abspath(os.path.join(__file__, "..", "..", "backend", executable))

--- a/executorlib/shared/executor.py
+++ b/executorlib/shared/executor.py
@@ -1,6 +1,5 @@
 import importlib.util
 import inspect
-import os
 import queue
 import sys
 from concurrent.futures import (
@@ -14,6 +13,7 @@ from typing import Callable, List, Optional
 
 import cloudpickle
 
+from executorlib.shared.command import get_command_path
 from executorlib.shared.communication import interface_bootup
 from executorlib.shared.inputcheck import (
     check_resource_dict,
@@ -463,19 +463,6 @@ def execute_tasks_with_dependencies(
         else:
             # If there is nothing else to do, sleep for a moment
             sleep(refresh_rate)
-
-
-def get_command_path(executable: str) -> str:
-    """
-    Get path of the backend executable script
-
-    Args:
-        executable (str): Name of the backend executable script, either mpiexec.py or serial.py
-
-    Returns:
-        str: absolute path to the executable script
-    """
-    return os.path.abspath(os.path.join(__file__, "..", "..", "backend", executable))
 
 
 def _get_backend_path(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new function to retrieve the absolute path for backend executable scripts.
- **Enhancements**
	- Improved resource management during task submissions with additional parameters.
	- Enhanced shutdown procedures for better control over multiple processes.
- **Bug Fixes**
	- Removed an unused function to streamline the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->