### PR TITLE
Cache: Use absolute path for working directory

### DIFF
--- a/executorlib/standalone/cache/queue.py
+++ b/executorlib/standalone/cache/queue.py
@@ -1,3 +1,4 @@
+import os
 from typing import List, Optional
 
 from pysqa import QueueAdapter
@@ -32,7 +33,7 @@ def execute_with_pysqa(
     submit_kwargs = {
         "command": " ".join(command),
         "dependency_list": [str(qid) for qid in task_dependent_lst],
-        "working_directory": resource_dict["cwd"],
+        "working_directory": os.path.abspath(resource_dict["cwd"]),
     }
     del resource_dict["cwd"]
     unsupported_keys = [

--- a/tests/test_cache_executor_pysqa_flux.py
+++ b/tests/test_cache_executor_pysqa_flux.py
@@ -34,7 +34,7 @@ class TestCacheExecutorPysqa(unittest.TestCase):
     def test_executor(self):
         with Executor(
             backend="pysqa_flux",
-            resource_dict={"cores": 2, "cwd": os.path.abspath("cwd")},
+            resource_dict={"cores": 2, "cwd": "exe_working_directory"},
             block_allocation=False,
         ) as exe:
             cloudpickle_register(ind=1)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of the working directory by ensuring it is converted to an absolute path before submission, enhancing robustness against path-related issues.

- **Tests**
	- Updated test cases to reflect changes in the working directory definition, ensuring accurate testing of the executor's functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->