### PR TITLE
Use same cache directory

### DIFF
--- a/tests/test_cache_executor_pysqa_flux.py
+++ b/tests/test_cache_executor_pysqa_flux.py
@@ -34,8 +34,9 @@ class TestCacheExecutorPysqa(unittest.TestCase):
     def test_executor(self):
         with Executor(
             backend="pysqa_flux",
-            resource_dict={"cores": 2, "cwd": "exe_working_directory"},
+            resource_dict={"cores": 2, "cwd": "cache"},
             block_allocation=False,
+            cache_directory="cache",
         ) as exe:
             cloudpickle_register(ind=1)
             fs1 = exe.submit(mpi_funct, 1)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Updated test configurations for the `Executor` to improve resource allocation and cache file management during test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->