### PR TITLE
Add option to disable_dependencies for cache

### DIFF
--- a/executorlib/__init__.py
+++ b/executorlib/__init__.py
@@ -195,6 +195,7 @@ class Executor:
                 hostname_localhost=hostname_localhost,
                 block_allocation=block_allocation,
                 init_function=init_function,
+                disable_dependencies=disable_dependencies,
             )
         elif not disable_dependencies:
             _check_pysqa_config_directory(pysqa_config_directory=pysqa_config_directory)

--- a/executorlib/cache/executor.py
+++ b/executorlib/cache/executor.py
@@ -32,6 +32,7 @@ class FileExecutor(ExecutorBase):
         terminate_function: Optional[callable] = None,
         pysqa_config_directory: Optional[str] = None,
         backend: Optional[str] = None,
+        disable_dependencies: bool = False,
     ):
         """
         Initialize the FileExecutor.
@@ -45,6 +46,7 @@ class FileExecutor(ExecutorBase):
             terminate_function (callable, optional): The function to terminate the tasks.
             pysqa_config_directory (str, optional): path to the pysqa config directory (only for pysqa based backend).
             backend (str, optional): name of the backend used to spawn tasks.
+            disable_dependencies (boolean): Disable resolving future objects during the submission.
         """
         super().__init__()
         default_resource_dict = {
@@ -71,6 +73,7 @@ class FileExecutor(ExecutorBase):
                     "terminate_function": terminate_function,
                     "pysqa_config_directory": pysqa_config_directory,
                     "backend": backend,
+                    "disable_dependencies": disable_dependencies,
                 },
             )
         )
@@ -89,6 +92,7 @@ def create_file_executor(
     hostname_localhost: Optional[bool] = None,
     block_allocation: bool = False,
     init_function: Optional[callable] = None,
+    disable_dependencies: bool = False,
 ):
     if cache_directory is None:
         cache_directory = "executorlib_cache"
@@ -110,4 +114,5 @@ def create_file_executor(
         resource_dict=resource_dict,
         pysqa_config_directory=pysqa_config_directory,
         backend=backend.split("pysqa_")[-1],
+        disable_dependencies=disable_dependencies,
     )

--- a/executorlib/cache/shared.py
+++ b/executorlib/cache/shared.py
@@ -118,7 +118,9 @@ def execute_tasks_h5(
                         ]
                     else:
                         if len(future_wait_key_lst) > 0:
-                            raise ValueError("Future objects are not supported as input if disable_dependencies=True.")
+                            raise ValueError(
+                                "Future objects are not supported as input if disable_dependencies=True."
+                            )
                         task_dependent_lst = []
                     process_dict[task_key] = execute_function(
                         command=_get_execute_command(

--- a/tests/test_cache_executor_serial.py
+++ b/tests/test_cache_executor_serial.py
@@ -48,7 +48,9 @@ class TestCacheExecutorSerial(unittest.TestCase):
 
     def test_executor_dependence_error(self):
         with self.assertRaises(ValueError):
-            with FileExecutor(execute_function=execute_in_subprocess, disable_dependencies=True) as exe:
+            with FileExecutor(
+                execute_function=execute_in_subprocess, disable_dependencies=True
+            ) as exe:
                 exe.submit(my_funct, 1, b=exe.submit(my_funct, 1, b=2))
 
     def test_executor_working_directory(self):

--- a/tests/test_cache_executor_serial.py
+++ b/tests/test_cache_executor_serial.py
@@ -46,6 +46,11 @@ class TestCacheExecutorSerial(unittest.TestCase):
             self.assertEqual(fs2.result(), 4)
             self.assertTrue(fs2.done())
 
+    def test_executor_dependence_error(self):
+        with self.assertRaises(ValueError):
+            with FileExecutor(execute_function=execute_in_subprocess, disable_dependencies=True) as exe:
+                exe.submit(my_funct, 1, b=exe.submit(my_funct, 1, b=2))
+
     def test_executor_working_directory(self):
         cwd = os.path.join(os.path.dirname(__file__), "executables")
         with FileExecutor(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a `disable_dependencies` parameter to the `Executor` and `FileExecutor` classes, allowing users to control dependency resolution during task submission.
	- Enhanced the `execute_tasks_h5` function to handle task execution with or without dependencies.

- **Bug Fixes**
	- Added error handling to raise a `ValueError` when tasks with dependencies are submitted while `disable_dependencies` is set to `True`.

- **Tests**
	- Added a new test case to ensure proper error handling when submitting tasks with dependencies disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->