### PR TITLE
Fix resource dict in interactive jobs

### DIFF
--- a/executorlib/interactive/shared.py
+++ b/executorlib/interactive/shared.py
@@ -593,7 +593,7 @@ def _execute_task_with_cache(
         fn=task_dict["fn"],
         fn_args=task_dict["args"],
         fn_kwargs=task_dict["kwargs"],
-        resource_dict=task_dict["resource_dict"],
+        resource_dict=task_dict.get("resource_dict", {}),
     )
     os.makedirs(cache_directory, exist_ok=True)
     file_name = os.path.join(cache_directory, task_key + ".h5out")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling by ensuring a default value is used for `resource_dict`, preventing potential errors when it is missing.

- **Chores**
	- Enhanced the robustness of the caching mechanism in task execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->