### PR TITLE
pysqa: set default jobname to pysqa

### DIFF
--- a/executorlib/standalone/cache/queue.py
+++ b/executorlib/standalone/cache/queue.py
@@ -57,6 +57,8 @@ def execute_with_pysqa(
     for k in unsupported_keys:
         if k in resource_dict:
             del resource_dict[k]
+    if "job_name" not in resource_dict:
+        resource_dict["job_name"] = "pysqa"
     submit_kwargs.update(resource_dict)
     return qa.submit_job(**submit_kwargs)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a default job name for submissions, ensuring every job has a name even if not explicitly provided.
  
- **Bug Fixes**
	- Improved handling of job submissions by ensuring a consistent job name is assigned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->