### PR TITLE
Test openmpi 5.0.6

### DIFF
--- a/.ci_support/environment-openmpi.yml
+++ b/.ci_support/environment-openmpi.yml
@@ -3,7 +3,7 @@ channels:
 dependencies:
 - python
 - numpy
-- openmpi =5.0.5
+- openmpi =5.0.6
 - cloudpickle =3.1.0
 - mpi4py =4.0.1
 - pyzmq =26.2.0

--- a/.ci_support/environment-openmpi.yml
+++ b/.ci_support/environment-openmpi.yml
@@ -3,7 +3,7 @@ channels:
 dependencies:
 - python
 - numpy
-- openmpi =5.0.6
+- openmpi
 - cloudpickle =3.1.0
 - mpi4py =4.0.1
 - pyzmq =26.2.0

--- a/tests/test_local_executor.py
+++ b/tests/test_local_executor.py
@@ -400,7 +400,7 @@ class TestFuturePool(unittest.TestCase):
             self.assertEqual(len(p), 1)
             self.assertTrue(isinstance(output, Future))
             self.assertFalse(output.done())
-            sleep(1)
+            sleep(2)
             self.assertTrue(output.done())
             self.assertEqual(len(p), 0)
         self.assertEqual(output.result(), [(2, 2, 0), (2, 2, 1)])


### PR DESCRIPTION
[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/pyiron/executorlib/openmpi)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the `openmpi` dependency version from 5.0.5 to 5.0.6 to enhance performance and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->