### PR TITLE
Update mpi4py to 4.0.2

### DIFF
--- a/.ci_support/environment-docs.yml
+++ b/.ci_support/environment-docs.yml
@@ -8,7 +8,7 @@ dependencies:
 - numpy
 - openmpi
 - cloudpickle =3.1.1
-- mpi4py =4.0.1
+- mpi4py =4.0.2
 - pyzmq =26.2.1
 - flux-core
 - jupyter-book =1.0.0

--- a/.ci_support/environment-mpich.yml
+++ b/.ci_support/environment-mpich.yml
@@ -5,7 +5,7 @@ dependencies:
 - numpy
 - mpich
 - cloudpickle =3.1.1
-- mpi4py =4.0.1
+- mpi4py =4.0.2
 - pyzmq =26.2.1
 - h5py =3.12.1
 - networkx =3.4.2

--- a/.ci_support/environment-openmpi.yml
+++ b/.ci_support/environment-openmpi.yml
@@ -5,7 +5,7 @@ dependencies:
 - numpy
 - openmpi
 - cloudpickle =3.1.1
-- mpi4py =4.0.1
+- mpi4py =4.0.2
 - pyzmq =26.2.1
 - h5py =3.12.1
 - networkx =3.4.2

--- a/.ci_support/environment-win.yml
+++ b/.ci_support/environment-win.yml
@@ -5,7 +5,7 @@ dependencies:
 - numpy
 - msmpi
 - cloudpickle =3.1.1
-- mpi4py =4.0.1
+- mpi4py =4.0.2
 - pyzmq =26.2.1
 - h5py =3.12.1
 - networkx =3.4.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ graphnotebook = [
     "networkx==3.4.2",
     "ipython==8.31.0",
 ]
-mpi = ["mpi4py==4.0.1"]
+mpi = ["mpi4py==4.0.2"]
 submission = [
     "pysqa==0.2.3",
     "h5py==3.12.1",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the MPI library dependency to version 4.0.2 across all configurations, ensuring enhanced consistency and reliability for parallel computing performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->