### PR TITLE
[minor] Rename test environment variable

### DIFF
--- a/.github/workflows/unittest-flux-openmpi.yml
+++ b/.github/workflows/unittest-flux-openmpi.yml
@@ -37,7 +37,7 @@ jobs:
         coverage run -a --omit="executorlib/_version.py,tests/*" -m unittest tests/test_flux_executor.py tests/test_executor_backend_flux.py tests/test_cache_executor_pysqa_flux.py tests/test_plot_dependency_flux.py;
         coverage xml
       env:
-        PYMPIPOOL_PMIX: "pmix"
+        EXECUTORLIB_PMIX: "pmix"
         TMPDIR: "/tmp"   # required by MacOs https://github.com/open-mpi/ompi/issues/7393
     - name: Coveralls
       uses: coverallsapp/github-action@v2

--- a/tests/test_cache_executor_pysqa_flux.py
+++ b/tests/test_cache_executor_pysqa_flux.py
@@ -10,7 +10,7 @@ try:
     import flux.job
 
     skip_flux_test = "FLUX_URI" not in os.environ
-    pmi = os.environ.get("PYMPIPOOL_PMIX", None)
+    pmi = os.environ.get("EXECUTORLIB_PMIX", None)
 except ImportError:
     skip_flux_test = True
 

--- a/tests/test_executor_backend_flux.py
+++ b/tests/test_executor_backend_flux.py
@@ -11,7 +11,7 @@ try:
     from executorlib.interactive.flux import FluxPythonSpawner
 
     skip_flux_test = "FLUX_URI" not in os.environ
-    pmi = os.environ.get("PYMPIPOOL_PMIX", None)
+    pmi = os.environ.get("EXECUTORLIB_PMIX", None)
 except ImportError:
     skip_flux_test = True
 

--- a/tests/test_flux_executor.py
+++ b/tests/test_flux_executor.py
@@ -15,7 +15,7 @@ try:
     from executorlib.interactive.flux import FluxPythonSpawner
 
     skip_flux_test = "FLUX_URI" not in os.environ
-    pmi = os.environ.get("PYMPIPOOL_PMIX", None)
+    pmi = os.environ.get("EXECUTORLIB_PMIX", None)
 except ImportError:
     skip_flux_test = True
 


### PR DESCRIPTION
Change PYMPIPOOL_PMIX to EXECUTORLIB_PMIX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Standardized internal environment configuration in testing workflows to ensure consistency.
- **Tests**
  - Updated test settings to align with the new configuration, supporting reliable executor integration during testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->