### PR TITLE
Use Python 3.11 for lower bound

### DIFF
--- a/.ci_support/environment-old.yml
+++ b/.ci_support/environment-old.yml
@@ -2,12 +2,12 @@ channels:
 - conda-forge
 dependencies:
 - python
-- numpy
+- numpy =1.23.5
 - openmpi =4.1.4
-- cloudpickle =2.0.0
+- cloudpickle =2.2.1
 - mpi4py =3.1.4
 - pyzmq =25.0.0
-- h5py =3.6.0
+- h5py =3.7.0
 - networkx =2.8.8
 - ipython =7.33.0
 - pygraphviz =1.10

--- a/.ci_support/environment-old.yml
+++ b/.ci_support/environment-old.yml
@@ -9,5 +9,5 @@ dependencies:
 - pyzmq =25.0.0
 - h5py =3.7.0
 - networkx =2.8.8
-- ipython =7.33.0
+- ipython =8.4.0
 - pygraphviz =1.10

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -257,9 +257,6 @@ jobs:
         - operating-system: ubuntu-latest
           python-version: '3.11'
 
-        - operating-system: ubuntu-latest
-          python-version: '3.10'
-
     steps:
     - uses: actions/checkout@v4
     - name: Conda config
@@ -297,9 +294,6 @@ jobs:
 
         - operating-system: ubuntu-latest
           python-version: '3.11'
-
-        - operating-system: ubuntu-latest
-          python-version: '3.10'
 
     steps:
     - uses: actions/checkout@v4
@@ -353,7 +347,7 @@ jobs:
       run: echo -e "channels:\n  - conda-forge\n" > .condarc
     - uses: conda-incubator/setup-miniconda@v3
       with:
-        python-version: '3.9'
+        python-version: '3.11'
         miniforge-version: latest
         condarc-file: .condarc
         environment-file: .ci_support/environment-old.yml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,8 +18,6 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Intended Audience :: Science/Research",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated key dependencies (including components for numerical and data processing) to enhance runtime stability.
  - Adjusted supported Python versions so the project now targets Python 3.11, 3.12, and 3.13.
  
- **Tests**
  - Refined the testing setup by streamlining the Python version matrix, ensuring alignment with the new compatibility standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->