### PR TITLE
h5py - 3.13.0

### DIFF
--- a/.ci_support/environment-docs.yml
+++ b/.ci_support/environment-docs.yml
@@ -12,5 +12,5 @@ dependencies:
 - pyzmq =26.2.1
 - flux-core
 - jupyter-book =1.0.0
-- h5py =3.12.1
+- h5py =3.13.0
 - python =3.12

--- a/.ci_support/environment-mpich.yml
+++ b/.ci_support/environment-mpich.yml
@@ -7,7 +7,7 @@ dependencies:
 - cloudpickle =3.1.1
 - mpi4py =4.0.1
 - pyzmq =26.2.1
-- h5py =3.12.1
+- h5py =3.13.0
 - networkx =3.4.2
 - pygraphviz =1.14
 - ipython =8.32.0

--- a/.ci_support/environment-openmpi.yml
+++ b/.ci_support/environment-openmpi.yml
@@ -7,7 +7,7 @@ dependencies:
 - cloudpickle =3.1.1
 - mpi4py =4.0.1
 - pyzmq =26.2.1
-- h5py =3.12.1
+- h5py =3.13.0
 - networkx =3.4.2
 - pygraphviz =1.14
 - pysqa =0.2.3

--- a/.ci_support/environment-win.yml
+++ b/.ci_support/environment-win.yml
@@ -7,7 +7,7 @@ dependencies:
 - cloudpickle =3.1.1
 - mpi4py =4.0.1
 - pyzmq =26.2.1
-- h5py =3.12.1
+- h5py =3.13.0
 - networkx =3.4.2
 - pygraphviz =1.14
 - ipython =8.32.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ Documentation = "https://executorlib.readthedocs.io"
 Repository = "https://github.com/pyiron/executorlib"
 
 [project.optional-dependencies]
-cache = ["h5py==3.12.1"]
+cache = ["h5py==3.13.0"]
 graph = [
     "pygraphviz==1.14",
     "networkx==3.4.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,12 +49,12 @@ graphnotebook = [
 mpi = ["mpi4py==4.0.1"]
 cluster = [
     "pysqa==0.2.3",
-    "h5py==3.12.1",
+    "h5py==3.13.0",
 ]
 all = [
     "mpi4py==4.0.1",
     "pysqa==0.2.3",
-    "h5py==3.12.1",
+    "h5py==3.13.0",
     "pygraphviz==1.14",
     "networkx==3.4.2",
     "ipython==8.32.0",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Upgraded the h5py library from version 3.12.1 to 3.13.0 across all environments, ensuring improved consistency and performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->