### PR TITLE
Bump setuptools from 80.1.0 to 80.3.1 (#646)

### DIFF
--- a/.ci_support/environment-mpich.yml
+++ b/.ci_support/environment-mpich.yml
@@ -12,4 +12,4 @@ dependencies:
 - pygraphviz =1.14
 - ipython =9.0.2
 - pysqa =0.2.4
-- setuptools =80.1.0
+- setuptools =80.3.1

--- a/.ci_support/environment-openmpi.yml
+++ b/.ci_support/environment-openmpi.yml
@@ -12,4 +12,4 @@ dependencies:
 - pygraphviz =1.14
 - pysqa =0.2.4
 - ipython =9.0.2
-- setuptools =80.1.0
+- setuptools =80.3.1

--- a/.ci_support/environment-win.yml
+++ b/.ci_support/environment-win.yml
@@ -11,4 +11,4 @@ dependencies:
 - networkx =3.4.2
 - pygraphviz =1.14
 - ipython =9.0.2
-- setuptools =80.1.0
+- setuptools =80.3.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "cloudpickle==3.1.1",
     "pyzmq==26.4.0",
-    "setuptools==80.1.0",
+    "setuptools==80.3.1",
     "versioneer[toml]==0.29",
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
* Bump setuptools from 80.1.0 to 80.3.1

Bumps [setuptools](https://github.com/pypa/setuptools) from 80.1.0 to 80.3.1.
- [Release notes](https://github.com/pypa/setuptools/releases)
- [Changelog](https://github.com/pypa/setuptools/blob/main/NEWS.rst)
- [Commits](https://github.com/pypa/setuptools/compare/v80.1.0...v80.3.1)

---
updated-dependencies:
- dependency-name: setuptools dependency-version: 80.3.1 dependency-type: direct:production update-type: version-update:semver-minor ...



* [dependabot skip] Update environment

---------