### PR TITLE
Define ExecutorBase in base module

### DIFF
--- a/executorlib/__init__.py
+++ b/executorlib/__init__.py
@@ -1,3 +1,4 @@
+from executorlib.executor.base import ExecutorBase
 from executorlib.executor.flux import (
     FluxClusterExecutor,
     FluxJobExecutor,
@@ -13,6 +14,7 @@ from . import _version
 
 __all__: list[str] = [
     "get_cache_data",
+    "ExecutorBase",
     "FluxJobExecutor",
     "FluxClusterExecutor",
     "SingleNodeExecutor",

--- a/executorlib/__init__.py
+++ b/executorlib/__init__.py
@@ -1,4 +1,4 @@
-from executorlib.executor.base import ExecutorBase
+from executorlib.executor.base import BaseExecutor
 from executorlib.executor.flux import (
     FluxClusterExecutor,
     FluxJobExecutor,
@@ -14,7 +14,7 @@ from . import _version
 
 __all__: list[str] = [
     "get_cache_data",
-    "ExecutorBase",
+    "BaseExecutor",
     "FluxJobExecutor",
     "FluxClusterExecutor",
     "SingleNodeExecutor",

--- a/executorlib/executor/base.py
+++ b/executorlib/executor/base.py
@@ -11,7 +11,7 @@ from typing import Callable, Optional
 from executorlib.task_scheduler.base import TaskSchedulerBase
 
 
-class ExecutorBase(FutureExecutor, ABC):
+class BaseExecutor(FutureExecutor, ABC):
     """
     Interface class for the executor.
 

--- a/executorlib/executor/base.py
+++ b/executorlib/executor/base.py
@@ -1,4 +1,5 @@
 import queue
+from abc import ABC
 from concurrent.futures import (
     Executor as FutureExecutor,
 )
@@ -10,7 +11,7 @@ from typing import Callable, Optional
 from executorlib.task_scheduler.base import TaskSchedulerBase
 
 
-class ExecutorBase(FutureExecutor):
+class ExecutorBase(FutureExecutor, ABC):
     """
     Interface class for the executor.
 

--- a/executorlib/executor/flux.py
+++ b/executorlib/executor/flux.py
@@ -1,6 +1,6 @@
 from typing import Callable, Optional, Union
 
-from executorlib.executor.base import ExecutorBase
+from executorlib.executor.base import BaseExecutor
 from executorlib.standalone.inputcheck import (
     check_command_line_argument_lst,
     check_init_function,
@@ -17,7 +17,7 @@ from executorlib.task_scheduler.interactive.dependency import DependencyTaskSche
 from executorlib.task_scheduler.interactive.onetoone import OneProcessTaskScheduler
 
 
-class FluxJobExecutor(ExecutorBase):
+class FluxJobExecutor(BaseExecutor):
     """
     The executorlib.Executor leverages either the message passing interface (MPI), the SLURM workload manager or
     preferable the flux framework for distributing python functions within a given resource allocation. In contrast to
@@ -202,7 +202,7 @@ class FluxJobExecutor(ExecutorBase):
             )
 
 
-class FluxClusterExecutor(ExecutorBase):
+class FluxClusterExecutor(BaseExecutor):
     """
     The executorlib.Executor leverages either the message passing interface (MPI), the SLURM workload manager or
     preferable the flux framework for distributing python functions within a given resource allocation. In contrast to

--- a/executorlib/executor/single.py
+++ b/executorlib/executor/single.py
@@ -1,6 +1,6 @@
 from typing import Callable, Optional, Union
 
-from executorlib.executor.base import ExecutorBase
+from executorlib.executor.base import BaseExecutor
 from executorlib.standalone.inputcheck import (
     check_command_line_argument_lst,
     check_gpus_per_worker,
@@ -17,7 +17,7 @@ from executorlib.task_scheduler.interactive.dependency import DependencyTaskSche
 from executorlib.task_scheduler.interactive.onetoone import OneProcessTaskScheduler
 
 
-class SingleNodeExecutor(ExecutorBase):
+class SingleNodeExecutor(BaseExecutor):
     """
     The executorlib.Executor leverages either the message passing interface (MPI), the SLURM workload manager or
     preferable the flux framework for distributing python functions within a given resource allocation. In contrast to

--- a/executorlib/executor/slurm.py
+++ b/executorlib/executor/slurm.py
@@ -1,6 +1,6 @@
 from typing import Callable, Optional, Union
 
-from executorlib.executor.base import ExecutorBase
+from executorlib.executor.base import BaseExecutor
 from executorlib.standalone.inputcheck import (
     check_init_function,
     check_plot_dependency_graph,
@@ -18,7 +18,7 @@ from executorlib.task_scheduler.interactive.slurmspawner import (
 )
 
 
-class SlurmClusterExecutor(ExecutorBase):
+class SlurmClusterExecutor(BaseExecutor):
     """
     The executorlib.Executor leverages either the message passing interface (MPI), the SLURM workload manager or
     preferable the flux framework for distributing python functions within a given resource allocation. In contrast to
@@ -194,7 +194,7 @@ class SlurmClusterExecutor(ExecutorBase):
             )
 
 
-class SlurmJobExecutor(ExecutorBase):
+class SlurmJobExecutor(BaseExecutor):
     """
     The executorlib.Executor leverages either the message passing interface (MPI), the SLURM workload manager or
     preferable the flux framework for distributing python functions within a given resource allocation. In contrast to


### PR DESCRIPTION
This is helpful for identifying if a software package received an executor from executorlib.
```python
from executorlib import BaseExecutor, SingleNodeExecutor

exe = SingleNodeExecutor()
print(isinstance(exe, BaseExecutor))
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Chores**
  - Renamed the base executor class from `ExecutorBase` to `BaseExecutor`.
  - Updated executor classes to inherit from the renamed base class.
  - Made `BaseExecutor` publicly accessible in the package exports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->