### PR TITLE
[Feature] Log Communication overhead

### DIFF
--- a/executorlib/executor/flux.py
+++ b/executorlib/executor/flux.py
@@ -61,7 +61,7 @@ class FluxJobExecutor(BaseExecutor):
         plot_dependency_graph (bool): Plot the dependencies of multiple future objects without executing them. For
                                       debugging purposes and to get an overview of the specified dependencies.
         plot_dependency_graph_filename (str): Name of the file to store the plotted graph in.
-        log_size_of_communicated_objects (bool): Enable debug mode which reports the size of the communicated objects.
+        log_obj_size (bool): Enable debug mode which reports the size of the communicated objects.
 
     Examples:
         ```
@@ -101,7 +101,7 @@ class FluxJobExecutor(BaseExecutor):
         refresh_rate: float = 0.01,
         plot_dependency_graph: bool = False,
         plot_dependency_graph_filename: Optional[str] = None,
-        log_size_of_communicated_objects: bool = False,
+        log_obj_size: bool = False,
     ):
         """
         The executorlib.FluxJobExecutor leverages either the message passing interface (MPI), the SLURM workload manager
@@ -146,7 +146,7 @@ class FluxJobExecutor(BaseExecutor):
             plot_dependency_graph (bool): Plot the dependencies of multiple future objects without executing them. For
                                           debugging purposes and to get an overview of the specified dependencies.
             plot_dependency_graph_filename (str): Name of the file to store the plotted graph in.
-            log_size_of_communicated_objects (bool): Enable debug mode which reports the size of the communicated objects.
+            log_obj_size (bool): Enable debug mode which reports the size of the communicated objects.
 
         """
         default_resource_dict: dict = {
@@ -177,7 +177,7 @@ class FluxJobExecutor(BaseExecutor):
                         hostname_localhost=hostname_localhost,
                         block_allocation=block_allocation,
                         init_function=init_function,
-                        log_size_of_communicated_objects=log_size_of_communicated_objects,
+                        log_obj_size=log_obj_size,
                     ),
                     max_cores=max_cores,
                     refresh_rate=refresh_rate,
@@ -201,7 +201,7 @@ class FluxJobExecutor(BaseExecutor):
                     hostname_localhost=hostname_localhost,
                     block_allocation=block_allocation,
                     init_function=init_function,
-                    log_size_of_communicated_objects=log_size_of_communicated_objects,
+                    log_obj_size=log_obj_size,
                 )
             )
 
@@ -397,7 +397,7 @@ def create_flux_executor(
     hostname_localhost: Optional[bool] = None,
     block_allocation: bool = False,
     init_function: Optional[Callable] = None,
-    log_size_of_communicated_objects: bool = False,
+    log_obj_size: bool = False,
 ) -> Union[OneProcessTaskScheduler, BlockAllocationTaskScheduler]:
     """
     Create a flux executor
@@ -433,7 +433,7 @@ def create_flux_executor(
                                     resources have to be defined on the executor, rather than during the submission
                                     of the individual function.
         init_function (None): optional function to preset arguments for functions which are submitted later
-        log_size_of_communicated_objects (bool): Enable debug mode which reports the size of the communicated objects.
+        log_obj_size (bool): Enable debug mode which reports the size of the communicated objects.
 
     Returns:
         InteractiveStepExecutor/ InteractiveExecutor
@@ -448,7 +448,7 @@ def create_flux_executor(
     cores_per_worker = resource_dict.get("cores", 1)
     resource_dict["cache_directory"] = cache_directory
     resource_dict["hostname_localhost"] = hostname_localhost
-    resource_dict["log_size_of_communicated_objects"] = log_size_of_communicated_objects
+    resource_dict["log_obj_size"] = log_obj_size
     check_init_function(block_allocation=block_allocation, init_function=init_function)
     check_pmi(backend="flux_allocation", pmi=flux_executor_pmi_mode)
     check_oversubscribe(oversubscribe=resource_dict.get("openmpi_oversubscribe", False))

--- a/executorlib/executor/flux.py
+++ b/executorlib/executor/flux.py
@@ -61,6 +61,7 @@ class FluxJobExecutor(BaseExecutor):
         plot_dependency_graph (bool): Plot the dependencies of multiple future objects without executing them. For
                                       debugging purposes and to get an overview of the specified dependencies.
         plot_dependency_graph_filename (str): Name of the file to store the plotted graph in.
+        log_size_of_communicated_objects (bool): Enable debug mode which reports the size of the communicated objects.
 
     Examples:
         ```
@@ -100,6 +101,7 @@ class FluxJobExecutor(BaseExecutor):
         refresh_rate: float = 0.01,
         plot_dependency_graph: bool = False,
         plot_dependency_graph_filename: Optional[str] = None,
+        log_size_of_communicated_objects: bool = False,
     ):
         """
         The executorlib.FluxJobExecutor leverages either the message passing interface (MPI), the SLURM workload manager
@@ -144,6 +146,7 @@ class FluxJobExecutor(BaseExecutor):
             plot_dependency_graph (bool): Plot the dependencies of multiple future objects without executing them. For
                                           debugging purposes and to get an overview of the specified dependencies.
             plot_dependency_graph_filename (str): Name of the file to store the plotted graph in.
+            log_size_of_communicated_objects (bool): Enable debug mode which reports the size of the communicated objects.
 
         """
         default_resource_dict: dict = {
@@ -174,6 +177,7 @@ class FluxJobExecutor(BaseExecutor):
                         hostname_localhost=hostname_localhost,
                         block_allocation=block_allocation,
                         init_function=init_function,
+                        log_size_of_communicated_objects=log_size_of_communicated_objects,
                     ),
                     max_cores=max_cores,
                     refresh_rate=refresh_rate,
@@ -197,6 +201,7 @@ class FluxJobExecutor(BaseExecutor):
                     hostname_localhost=hostname_localhost,
                     block_allocation=block_allocation,
                     init_function=init_function,
+                    log_size_of_communicated_objects=log_size_of_communicated_objects,
                 )
             )
 
@@ -392,6 +397,7 @@ def create_flux_executor(
     hostname_localhost: Optional[bool] = None,
     block_allocation: bool = False,
     init_function: Optional[Callable] = None,
+    log_size_of_communicated_objects: bool = False,
 ) -> Union[OneProcessTaskScheduler, BlockAllocationTaskScheduler]:
     """
     Create a flux executor
@@ -427,6 +433,7 @@ def create_flux_executor(
                                     resources have to be defined on the executor, rather than during the submission
                                     of the individual function.
         init_function (None): optional function to preset arguments for functions which are submitted later
+        log_size_of_communicated_objects (bool): Enable debug mode which reports the size of the communicated objects.
 
     Returns:
         InteractiveStepExecutor/ InteractiveExecutor
@@ -441,6 +448,7 @@ def create_flux_executor(
     cores_per_worker = resource_dict.get("cores", 1)
     resource_dict["cache_directory"] = cache_directory
     resource_dict["hostname_localhost"] = hostname_localhost
+    resource_dict["log_size_of_communicated_objects"] = log_size_of_communicated_objects
     check_init_function(block_allocation=block_allocation, init_function=init_function)
     check_pmi(backend="flux_allocation", pmi=flux_executor_pmi_mode)
     check_oversubscribe(oversubscribe=resource_dict.get("openmpi_oversubscribe", False))

--- a/executorlib/executor/single.py
+++ b/executorlib/executor/single.py
@@ -91,7 +91,7 @@ class SingleNodeExecutor(BaseExecutor):
         refresh_rate: float = 0.01,
         plot_dependency_graph: bool = False,
         plot_dependency_graph_filename: Optional[str] = None,
-        log_size_of_communicated_objects: bool = False,
+        log_obj_size: bool = False,
     ):
         """
         The executorlib.SingleNodeExecutor leverages either the message passing interface (MPI), the SLURM workload
@@ -132,7 +132,7 @@ class SingleNodeExecutor(BaseExecutor):
             plot_dependency_graph (bool): Plot the dependencies of multiple future objects without executing them. For
                                           debugging purposes and to get an overview of the specified dependencies.
             plot_dependency_graph_filename (str): Name of the file to store the plotted graph in.
-            log_size_of_communicated_objects (bool): Enable debug mode which reports the size of the communicated objects.
+            log_obj_size (bool): Enable debug mode which reports the size of the communicated objects.
 
         """
         default_resource_dict: dict = {
@@ -159,7 +159,7 @@ class SingleNodeExecutor(BaseExecutor):
                         hostname_localhost=hostname_localhost,
                         block_allocation=block_allocation,
                         init_function=init_function,
-                        log_size_of_communicated_objects=log_size_of_communicated_objects,
+                        log_obj_size=log_obj_size,
                     ),
                     max_cores=max_cores,
                     refresh_rate=refresh_rate,
@@ -179,7 +179,7 @@ class SingleNodeExecutor(BaseExecutor):
                     hostname_localhost=hostname_localhost,
                     block_allocation=block_allocation,
                     init_function=init_function,
-                    log_size_of_communicated_objects=log_size_of_communicated_objects,
+                    log_obj_size=log_obj_size,
                 )
             )
 
@@ -192,7 +192,7 @@ def create_single_node_executor(
     hostname_localhost: Optional[bool] = None,
     block_allocation: bool = False,
     init_function: Optional[Callable] = None,
-    log_size_of_communicated_objects: bool = False,
+    log_obj_size: bool = False,
 ) -> Union[OneProcessTaskScheduler, BlockAllocationTaskScheduler]:
     """
     Create a single node executor
@@ -224,7 +224,7 @@ def create_single_node_executor(
                                     resources have to be defined on the executor, rather than during the submission
                                     of the individual function.
         init_function (None): optional function to preset arguments for functions which are submitted later
-        log_size_of_communicated_objects (bool): Enable debug mode which reports the size of the communicated objects.
+        log_obj_size (bool): Enable debug mode which reports the size of the communicated objects.
 
     Returns:
         InteractiveStepExecutor/ InteractiveExecutor
@@ -234,7 +234,7 @@ def create_single_node_executor(
     cores_per_worker = resource_dict.get("cores", 1)
     resource_dict["cache_directory"] = cache_directory
     resource_dict["hostname_localhost"] = hostname_localhost
-    resource_dict["log_size_of_communicated_objects"] = log_size_of_communicated_objects
+    resource_dict["log_obj_size"] = log_obj_size
 
     check_init_function(block_allocation=block_allocation, init_function=init_function)
     check_gpus_per_worker(gpus_per_worker=resource_dict.get("gpus_per_core", 0))

--- a/executorlib/executor/single.py
+++ b/executorlib/executor/single.py
@@ -91,6 +91,7 @@ class SingleNodeExecutor(BaseExecutor):
         refresh_rate: float = 0.01,
         plot_dependency_graph: bool = False,
         plot_dependency_graph_filename: Optional[str] = None,
+        log_size_of_communicated_objects: bool = False,
     ):
         """
         The executorlib.SingleNodeExecutor leverages either the message passing interface (MPI), the SLURM workload
@@ -131,6 +132,7 @@ class SingleNodeExecutor(BaseExecutor):
             plot_dependency_graph (bool): Plot the dependencies of multiple future objects without executing them. For
                                           debugging purposes and to get an overview of the specified dependencies.
             plot_dependency_graph_filename (str): Name of the file to store the plotted graph in.
+            log_size_of_communicated_objects (bool): Enable debug mode which reports the size of the communicated objects.
 
         """
         default_resource_dict: dict = {
@@ -157,6 +159,7 @@ class SingleNodeExecutor(BaseExecutor):
                         hostname_localhost=hostname_localhost,
                         block_allocation=block_allocation,
                         init_function=init_function,
+                        log_size_of_communicated_objects=log_size_of_communicated_objects,
                     ),
                     max_cores=max_cores,
                     refresh_rate=refresh_rate,
@@ -176,6 +179,7 @@ class SingleNodeExecutor(BaseExecutor):
                     hostname_localhost=hostname_localhost,
                     block_allocation=block_allocation,
                     init_function=init_function,
+                    log_size_of_communicated_objects=log_size_of_communicated_objects,
                 )
             )
 
@@ -188,6 +192,7 @@ def create_single_node_executor(
     hostname_localhost: Optional[bool] = None,
     block_allocation: bool = False,
     init_function: Optional[Callable] = None,
+    log_size_of_communicated_objects: bool = False,
 ) -> Union[OneProcessTaskScheduler, BlockAllocationTaskScheduler]:
     """
     Create a single node executor
@@ -219,6 +224,7 @@ def create_single_node_executor(
                                     resources have to be defined on the executor, rather than during the submission
                                     of the individual function.
         init_function (None): optional function to preset arguments for functions which are submitted later
+        log_size_of_communicated_objects (bool): Enable debug mode which reports the size of the communicated objects.
 
     Returns:
         InteractiveStepExecutor/ InteractiveExecutor
@@ -228,6 +234,7 @@ def create_single_node_executor(
     cores_per_worker = resource_dict.get("cores", 1)
     resource_dict["cache_directory"] = cache_directory
     resource_dict["hostname_localhost"] = hostname_localhost
+    resource_dict["log_size_of_communicated_objects"] = log_size_of_communicated_objects
 
     check_init_function(block_allocation=block_allocation, init_function=init_function)
     check_gpus_per_worker(gpus_per_worker=resource_dict.get("gpus_per_core", 0))

--- a/executorlib/executor/slurm.py
+++ b/executorlib/executor/slurm.py
@@ -236,6 +236,7 @@ class SlurmJobExecutor(BaseExecutor):
         plot_dependency_graph (bool): Plot the dependencies of multiple future objects without executing them. For
                                       debugging purposes and to get an overview of the specified dependencies.
         plot_dependency_graph_filename (str): Name of the file to store the plotted graph in.
+        log_size_of_communicated_objects (bool): Enable debug mode which reports the size of the communicated objects.
 
     Examples:
         ```
@@ -271,6 +272,7 @@ class SlurmJobExecutor(BaseExecutor):
         refresh_rate: float = 0.01,
         plot_dependency_graph: bool = False,
         plot_dependency_graph_filename: Optional[str] = None,
+        log_size_of_communicated_objects: bool = False,
     ):
         """
         The executorlib.SlurmJobExecutor leverages either the message passing interface (MPI), the SLURM workload
@@ -315,6 +317,7 @@ class SlurmJobExecutor(BaseExecutor):
             plot_dependency_graph (bool): Plot the dependencies of multiple future objects without executing them. For
                                           debugging purposes and to get an overview of the specified dependencies.
             plot_dependency_graph_filename (str): Name of the file to store the plotted graph in.
+            log_size_of_communicated_objects (bool): Enable debug mode which reports the size of the communicated objects.
 
         """
         default_resource_dict: dict = {
@@ -341,6 +344,7 @@ class SlurmJobExecutor(BaseExecutor):
                         hostname_localhost=hostname_localhost,
                         block_allocation=block_allocation,
                         init_function=init_function,
+                        log_size_of_communicated_objects=log_size_of_communicated_objects,
                     ),
                     max_cores=max_cores,
                     refresh_rate=refresh_rate,
@@ -360,6 +364,7 @@ class SlurmJobExecutor(BaseExecutor):
                     hostname_localhost=hostname_localhost,
                     block_allocation=block_allocation,
                     init_function=init_function,
+                    log_size_of_communicated_objects=log_size_of_communicated_objects,
                 )
             )
 
@@ -372,6 +377,7 @@ def create_slurm_executor(
     hostname_localhost: Optional[bool] = None,
     block_allocation: bool = False,
     init_function: Optional[Callable] = None,
+    log_size_of_communicated_objects: bool = False,
 ) -> Union[OneProcessTaskScheduler, BlockAllocationTaskScheduler]:
     """
     Create a SLURM executor
@@ -407,6 +413,7 @@ def create_slurm_executor(
                                     resources have to be defined on the executor, rather than during the submission
                                     of the individual function.
         init_function (None): optional function to preset arguments for functions which are submitted later
+        log_size_of_communicated_objects (bool): Enable debug mode which reports the size of the communicated objects.
 
     Returns:
         InteractiveStepExecutor/ InteractiveExecutor
@@ -416,6 +423,7 @@ def create_slurm_executor(
     cores_per_worker = resource_dict.get("cores", 1)
     resource_dict["cache_directory"] = cache_directory
     resource_dict["hostname_localhost"] = hostname_localhost
+    resource_dict["log_size_of_communicated_objects"] = log_size_of_communicated_objects
     check_init_function(block_allocation=block_allocation, init_function=init_function)
     if block_allocation:
         resource_dict["init_function"] = init_function

--- a/executorlib/executor/slurm.py
+++ b/executorlib/executor/slurm.py
@@ -236,7 +236,7 @@ class SlurmJobExecutor(BaseExecutor):
         plot_dependency_graph (bool): Plot the dependencies of multiple future objects without executing them. For
                                       debugging purposes and to get an overview of the specified dependencies.
         plot_dependency_graph_filename (str): Name of the file to store the plotted graph in.
-        log_size_of_communicated_objects (bool): Enable debug mode which reports the size of the communicated objects.
+        log_obj_size (bool): Enable debug mode which reports the size of the communicated objects.
 
     Examples:
         ```
@@ -272,7 +272,7 @@ class SlurmJobExecutor(BaseExecutor):
         refresh_rate: float = 0.01,
         plot_dependency_graph: bool = False,
         plot_dependency_graph_filename: Optional[str] = None,
-        log_size_of_communicated_objects: bool = False,
+        log_obj_size: bool = False,
     ):
         """
         The executorlib.SlurmJobExecutor leverages either the message passing interface (MPI), the SLURM workload
@@ -317,7 +317,7 @@ class SlurmJobExecutor(BaseExecutor):
             plot_dependency_graph (bool): Plot the dependencies of multiple future objects without executing them. For
                                           debugging purposes and to get an overview of the specified dependencies.
             plot_dependency_graph_filename (str): Name of the file to store the plotted graph in.
-            log_size_of_communicated_objects (bool): Enable debug mode which reports the size of the communicated objects.
+            log_obj_size (bool): Enable debug mode which reports the size of the communicated objects.
 
         """
         default_resource_dict: dict = {
@@ -344,7 +344,7 @@ class SlurmJobExecutor(BaseExecutor):
                         hostname_localhost=hostname_localhost,
                         block_allocation=block_allocation,
                         init_function=init_function,
-                        log_size_of_communicated_objects=log_size_of_communicated_objects,
+                        log_obj_size=log_obj_size,
                     ),
                     max_cores=max_cores,
                     refresh_rate=refresh_rate,
@@ -364,7 +364,7 @@ class SlurmJobExecutor(BaseExecutor):
                     hostname_localhost=hostname_localhost,
                     block_allocation=block_allocation,
                     init_function=init_function,
-                    log_size_of_communicated_objects=log_size_of_communicated_objects,
+                    log_obj_size=log_obj_size,
                 )
             )
 
@@ -377,7 +377,7 @@ def create_slurm_executor(
     hostname_localhost: Optional[bool] = None,
     block_allocation: bool = False,
     init_function: Optional[Callable] = None,
-    log_size_of_communicated_objects: bool = False,
+    log_obj_size: bool = False,
 ) -> Union[OneProcessTaskScheduler, BlockAllocationTaskScheduler]:
     """
     Create a SLURM executor
@@ -413,7 +413,7 @@ def create_slurm_executor(
                                     resources have to be defined on the executor, rather than during the submission
                                     of the individual function.
         init_function (None): optional function to preset arguments for functions which are submitted later
-        log_size_of_communicated_objects (bool): Enable debug mode which reports the size of the communicated objects.
+        log_obj_size (bool): Enable debug mode which reports the size of the communicated objects.
 
     Returns:
         InteractiveStepExecutor/ InteractiveExecutor
@@ -423,7 +423,7 @@ def create_slurm_executor(
     cores_per_worker = resource_dict.get("cores", 1)
     resource_dict["cache_directory"] = cache_directory
     resource_dict["hostname_localhost"] = hostname_localhost
-    resource_dict["log_size_of_communicated_objects"] = log_size_of_communicated_objects
+    resource_dict["log_obj_size"] = log_obj_size
     check_init_function(block_allocation=block_allocation, init_function=init_function)
     if block_allocation:
         resource_dict["init_function"] = init_function

--- a/executorlib/standalone/interactive/communication.py
+++ b/executorlib/standalone/interactive/communication.py
@@ -1,3 +1,4 @@
+import logging
 import sys
 from socket import gethostname
 from typing import Optional
@@ -24,6 +25,7 @@ class SocketInterface:
         self._context = zmq.Context()
         self._socket = self._context.socket(zmq.PAIR)
         self._process = None
+        self._logger = logging.getLogger("executorlib")
         self._spawner = spawner
 
     def send_dict(self, input_dict: dict):
@@ -34,7 +36,9 @@ class SocketInterface:
             input_dict (dict): dictionary of commands to be communicated. The key "shutdown" is reserved to stop the
                 connected client from listening.
         """
-        self._socket.send(cloudpickle.dumps(input_dict))
+        data = cloudpickle.dumps(input_dict)
+        self._logger.warning("Size of data: " + str(sys.getsizeof(data)))
+        self._socket.send(data)
 
     def receive_dict(self) -> dict:
         """

--- a/executorlib/standalone/interactive/communication.py
+++ b/executorlib/standalone/interactive/communication.py
@@ -13,10 +13,10 @@ class SocketInterface:
 
     Args:
         spawner (executorlib.shared.spawner.BaseSpawner): Interface for starting the parallel process
-        log_size_of_communicated_objects (boolean): Enable debug mode which reports the size of the communicated objects.
+        log_obj_size (boolean): Enable debug mode which reports the size of the communicated objects.
     """
 
-    def __init__(self, spawner=None, log_size_of_communicated_objects=False):
+    def __init__(self, spawner=None, log_obj_size=False):
         """
         Initialize the SocketInterface.
 
@@ -26,7 +26,7 @@ class SocketInterface:
         self._context = zmq.Context()
         self._socket = self._context.socket(zmq.PAIR)
         self._process = None
-        if log_size_of_communicated_objects:
+        if log_obj_size:
             self._logger = logging.getLogger("executorlib")
         else:
             self._logger = None
@@ -133,7 +133,7 @@ def interface_bootup(
     command_lst: list[str],
     connections,
     hostname_localhost: Optional[bool] = None,
-    log_size_of_communicated_objects: bool = False,
+    log_obj_size: bool = False,
 ) -> SocketInterface:
     """
     Start interface for ZMQ communication
@@ -149,7 +149,7 @@ def interface_bootup(
                                       points to the same address as localhost. Still MacOS >= 12 seems to disable
                                       this look up for security reasons. So on MacOS it is required to set this
                                       option to true
-        log_size_of_communicated_objects (boolean): Enable debug mode which reports the size of the communicated objects.
+        log_obj_size (boolean): Enable debug mode which reports the size of the communicated objects.
 
     Returns:
          executorlib.shared.communication.SocketInterface: socket interface for zmq communication
@@ -165,7 +165,7 @@ def interface_bootup(
         ]
     interface = SocketInterface(
         spawner=connections,
-        log_size_of_communicated_objects=log_size_of_communicated_objects,
+        log_obj_size=log_obj_size,
     )
     command_lst += [
         "--zmqport",

--- a/executorlib/task_scheduler/interactive/shared.py
+++ b/executorlib/task_scheduler/interactive/shared.py
@@ -23,7 +23,7 @@ def execute_tasks(
     init_function: Optional[Callable] = None,
     cache_directory: Optional[str] = None,
     queue_join_on_shutdown: bool = True,
-    log_size_of_communicated_objects: bool = False,
+    log_obj_size: bool = False,
     **kwargs,
 ) -> None:
     """
@@ -43,7 +43,7 @@ def execute_tasks(
        init_function (Callable): optional function to preset arguments for functions which are submitted later
        cache_directory (str, optional): The directory to store cache files. Defaults to "cache".
        queue_join_on_shutdown (bool): Join communication queue when thread is closed. Defaults to True.
-       log_size_of_communicated_objects (bool): Enable debug mode which reports the size of the communicated objects.
+       log_obj_size (bool): Enable debug mode which reports the size of the communicated objects.
     """
     interface = interface_bootup(
         command_lst=_get_backend_path(
@@ -51,7 +51,7 @@ def execute_tasks(
         ),
         connections=spawner(cores=cores, **kwargs),
         hostname_localhost=hostname_localhost,
-        log_size_of_communicated_objects=log_size_of_communicated_objects,
+        log_obj_size=log_obj_size,
     )
     if init_function is not None:
         interface.send_dict(

--- a/executorlib/task_scheduler/interactive/shared.py
+++ b/executorlib/task_scheduler/interactive/shared.py
@@ -23,6 +23,7 @@ def execute_tasks(
     init_function: Optional[Callable] = None,
     cache_directory: Optional[str] = None,
     queue_join_on_shutdown: bool = True,
+    log_size_of_communicated_objects: bool = False,
     **kwargs,
 ) -> None:
     """
@@ -42,6 +43,7 @@ def execute_tasks(
        init_function (Callable): optional function to preset arguments for functions which are submitted later
        cache_directory (str, optional): The directory to store cache files. Defaults to "cache".
        queue_join_on_shutdown (bool): Join communication queue when thread is closed. Defaults to True.
+       log_size_of_communicated_objects (bool): Enable debug mode which reports the size of the communicated objects.
     """
     interface = interface_bootup(
         command_lst=_get_backend_path(
@@ -49,6 +51,7 @@ def execute_tasks(
         ),
         connections=spawner(cores=cores, **kwargs),
         hostname_localhost=hostname_localhost,
+        log_size_of_communicated_objects=log_size_of_communicated_objects,
     )
     if init_function is not None:
         interface.send_dict(

--- a/tests/test_singlenodeexecutor_dependencies.py
+++ b/tests/test_singlenodeexecutor_dependencies.py
@@ -341,6 +341,7 @@ class TestInfo(unittest.TestCase):
             'openmpi_oversubscribe': False,
             'cache_directory': None,
             'hostname_localhost': None,
+            'log_obj_size': False,
             'spawner': MpiExecSpawner,
             'max_cores': None,
             'max_workers': None,

--- a/tests/test_standalone_interactive_communication.py
+++ b/tests/test_standalone_interactive_communication.py
@@ -61,7 +61,7 @@ class TestInterface(unittest.TestCase):
         task_dict = {"fn": calc, "args": (), "kwargs": {"i": 2}}
         interface = SocketInterface(
             spawner=MpiExecSpawner(cwd=None, cores=1, openmpi_oversubscribe=False),
-            log_size_of_communicated_objects=False,
+            log_obj_size=False,
         )
         interface.bootup(
             command_lst=[
@@ -90,7 +90,7 @@ class TestInterface(unittest.TestCase):
         task_dict = {"fn": calc, "args": (), "kwargs": {"i": 2}}
         interface = SocketInterface(
             spawner=MpiExecSpawner(cwd=None, cores=1, openmpi_oversubscribe=False),
-            log_size_of_communicated_objects=True,
+            log_obj_size=True,
         )
         interface.bootup(
             command_lst=[

--- a/tests/test_standalone_interactive_communication.py
+++ b/tests/test_standalone_interactive_communication.py
@@ -56,11 +56,41 @@ class TestInterface(unittest.TestCase):
         )
         interface.shutdown(wait=True)
 
-    def test_interface_serial(self):
+    def test_interface_serial_without_debug(self):
         cloudpickle_register(ind=1)
         task_dict = {"fn": calc, "args": (), "kwargs": {"i": 2}}
         interface = SocketInterface(
-            spawner=MpiExecSpawner(cwd=None, cores=1, openmpi_oversubscribe=False)
+            spawner=MpiExecSpawner(cwd=None, cores=1, openmpi_oversubscribe=False),
+            log_size_of_communicated_objects=False,
+        )
+        interface.bootup(
+            command_lst=[
+                sys.executable,
+                os.path.abspath(
+                    os.path.join(
+                        __file__,
+                        "..",
+                        "..",
+                        "executorlib",
+                        "backend",
+                        "interactive_serial.py",
+                    )
+                ),
+                "--zmqport",
+                str(interface.bind_to_random_port()),
+            ]
+        )
+        self.assertEqual(
+            interface.send_and_receive_dict(input_dict=task_dict), np.array(4)
+        )
+        interface.shutdown(wait=True)
+
+    def test_interface_serial_with_debug(self):
+        cloudpickle_register(ind=1)
+        task_dict = {"fn": calc, "args": (), "kwargs": {"i": 2}}
+        interface = SocketInterface(
+            spawner=MpiExecSpawner(cwd=None, cores=1, openmpi_oversubscribe=False),
+            log_size_of_communicated_objects=True,
         )
         interface.bootup(
             command_lst=[


### PR DESCRIPTION
Example: 
```python
from executorlib import SingleNodeExecutor

with SingleNodeExecutor(log_obj_size=True) as exe:
    future = exe.submit(sum, [1, 1])
    print(future.result())
```

log warnings: 
```
Send dictionary of size: 101
Received dictionary of size: 59
Send dictionary of size: 69
Received dictionary of size: 58
```

Result: 
```
2
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added an option to enable logging of object sizes during communication for various executors and interfaces. This can be activated with a new parameter in relevant constructors and functions.
- **Documentation**
	- Updated docstrings to describe the new logging parameter.
- **Tests**
	- Enhanced tests to cover scenarios with and without object size logging enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->