### PR TITLE
Ignore PLC0415

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,8 @@ select = [
 ignore = [
     # ignore line-length violations
     "E501",
+    # ignore imports which are not at the top of a module
+    "PLC0415",
     # Too many arguments in function definition
     "PLR0913",
     # Magic value used in comparison


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated linting configuration to ignore errors related to import statements not being at the top of Python modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->