### PR TITLE
Create cache directory only during dump()

### DIFF
--- a/executorlib/task_scheduler/file/task_scheduler.py
+++ b/executorlib/task_scheduler/file/task_scheduler.py
@@ -62,7 +62,6 @@ class FileTaskScheduler(TaskSchedulerBase):
         if execute_function == execute_in_subprocess and terminate_function is None:
             terminate_function = terminate_subprocess
         cache_directory_path = os.path.abspath(cache_directory)
-        os.makedirs(cache_directory_path, exist_ok=True)
         self._process_kwargs = {
             "future_queue": self._future_queue,
             "execute_function": execute_function,

--- a/executorlib/task_scheduler/interactive/shared.py
+++ b/executorlib/task_scheduler/interactive/shared.py
@@ -160,7 +160,6 @@ def _execute_task_with_cache(
         resource_dict=task_dict.get("resource_dict", {}),
         cache_key=cache_key,
     )
-    os.makedirs(cache_directory, exist_ok=True)
     file_name = os.path.abspath(os.path.join(cache_directory, task_key + "_o.h5"))
     if file_name not in get_cache_files(cache_directory=cache_directory):
         f = task_dict.pop("future")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed automatic creation of cache directories in task execution and scheduler components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->