### PR TITLE
Fix DocString in SingleNodeExecutor

### DIFF
--- a/executorlib/executor/single.py
+++ b/executorlib/executor/single.py
@@ -56,6 +56,7 @@ class SingleNodeExecutor(BaseExecutor):
         plot_dependency_graph (bool): Plot the dependencies of multiple future objects without executing them. For
                                       debugging purposes and to get an overview of the specified dependencies.
         plot_dependency_graph_filename (str): Name of the file to store the plotted graph in.
+        log_obj_size (bool): Enable debug mode which reports the size of the communicated objects.
 
     Examples:
         ```


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new option to enable debug reporting of communicated object sizes when using single-node execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->