### PR TITLE
remove unused parameter terminate_tasks_on_shutdown

### DIFF
--- a/executorlib/executor/flux.py
+++ b/executorlib/executor/flux.py
@@ -285,7 +285,6 @@ class FluxClusterExecutor(BaseExecutor):
         plot_dependency_graph: bool = False,
         plot_dependency_graph_filename: Optional[str] = None,
         log_obj_size: bool = False,
-        terminate_tasks_on_shutdown: bool = True,
     ):
         """
         The executorlib.FluxClusterExecutor leverages either the message passing interface (MPI), the SLURM workload

--- a/executorlib/executor/slurm.py
+++ b/executorlib/executor/slurm.py
@@ -97,7 +97,6 @@ class SlurmClusterExecutor(BaseExecutor):
         plot_dependency_graph: bool = False,
         plot_dependency_graph_filename: Optional[str] = None,
         log_obj_size: bool = False,
-        terminate_tasks_on_shutdown: bool = True,
     ):
         """
         The executorlib.SlurmClusterExecutor leverages either the message passing interface (MPI), the SLURM workload
@@ -281,7 +280,6 @@ class SlurmJobExecutor(BaseExecutor):
         plot_dependency_graph: bool = False,
         plot_dependency_graph_filename: Optional[str] = None,
         log_obj_size: bool = False,
-        terminate_tasks_on_shutdown: bool = True,
     ):
         """
         The executorlib.SlurmJobExecutor leverages either the message passing interface (MPI), the SLURM workload

--- a/tests/test_fluxclusterexecutor.py
+++ b/tests/test_fluxclusterexecutor.py
@@ -37,7 +37,6 @@ class TestCacheExecutorPysqa(unittest.TestCase):
             resource_dict={"cores": 2, "cwd": "executorlib_cache"},
             block_allocation=False,
             cache_directory="executorlib_cache",
-            terminate_tasks_on_shutdown=False,
         ) as exe:
             cloudpickle_register(ind=1)
             fs1 = exe.submit(mpi_funct, 1)
@@ -51,7 +50,6 @@ class TestCacheExecutorPysqa(unittest.TestCase):
             resource_dict={"cores": 2},
             block_allocation=False,
             cache_directory="executorlib_cache",
-            terminate_tasks_on_shutdown=True,
         ) as exe:
             cloudpickle_register(ind=1)
             fs1 = exe.submit(mpi_funct, 1)

--- a/tests/test_slurmclusterexecutor.py
+++ b/tests/test_slurmclusterexecutor.py
@@ -50,7 +50,6 @@ class TestCacheExecutorPysqa(unittest.TestCase):
             resource_dict={"cores": 2, "cwd": "executorlib_cache", "submission_template": submission_template},
             block_allocation=False,
             cache_directory="executorlib_cache",
-            terminate_tasks_on_shutdown=False,
         ) as exe:
             cloudpickle_register(ind=1)
             fs1 = exe.submit(mpi_funct, 1)
@@ -64,7 +63,6 @@ class TestCacheExecutorPysqa(unittest.TestCase):
             resource_dict={"cores": 2, "submission_template": submission_template},
             block_allocation=False,
             cache_directory="executorlib_cache",
-            terminate_tasks_on_shutdown=True,
         ) as exe:
             cloudpickle_register(ind=1)
             fs1 = exe.submit(mpi_funct, 1)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed the `terminate_tasks_on_shutdown` parameter from configuration options in relevant executors.

* **Tests**
  * Updated tests to reflect the removal of the `terminate_tasks_on_shutdown` parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->