### PR TITLE
Silence error when terminating jobs

### DIFF
--- a/executorlib/task_scheduler/file/queue_spawner.py
+++ b/executorlib/task_scheduler/file/queue_spawner.py
@@ -115,7 +115,6 @@ def terminate_with_pysqa(
             qa.delete_job(process_id=queue_id)
 
 
-
 def _pysqa_execute_command(
     commands: str,
     working_directory: Optional[str] = None,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when terminating jobs, preventing potential crashes if job deletion fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->