### PR TITLE
Rename serialize_funct()

### DIFF
--- a/executorlib/standalone/serialize.py
+++ b/executorlib/standalone/serialize.py
@@ -28,7 +28,7 @@ def cloudpickle_register(ind: int = 2):
         pass
 
 
-def serialize_funct_h5(
+def serialize_funct(
     fn: Callable,
     fn_args: Optional[list] = None,
     fn_kwargs: Optional[dict] = None,

--- a/executorlib/task_scheduler/file/shared.py
+++ b/executorlib/task_scheduler/file/shared.py
@@ -6,7 +6,7 @@ from typing import Any, Callable, Optional
 
 from executorlib.standalone.cache import get_cache_files
 from executorlib.standalone.command import get_cache_execute_command
-from executorlib.standalone.serialize import serialize_funct_h5
+from executorlib.standalone.serialize import serialize_funct
 from executorlib.task_scheduler.file.hdf import get_output
 from executorlib.task_scheduler.file.subprocess_spawner import terminate_subprocess
 
@@ -127,7 +127,7 @@ def execute_tasks_h5(
             cache_key = task_resource_dict.pop("cache_key", None)
             cache_directory = os.path.abspath(task_resource_dict.pop("cache_directory"))
             error_log_file = task_resource_dict.pop("error_log_file", None)
-            task_key, data_dict = serialize_funct_h5(
+            task_key, data_dict = serialize_funct(
                 fn=task_dict["fn"],
                 fn_args=task_args,
                 fn_kwargs=task_kwargs,

--- a/executorlib/task_scheduler/interactive/shared.py
+++ b/executorlib/task_scheduler/interactive/shared.py
@@ -11,7 +11,7 @@ from executorlib.standalone.interactive.communication import (
     interface_bootup,
 )
 from executorlib.standalone.interactive.spawner import BaseSpawner, MpiExecSpawner
-from executorlib.standalone.serialize import serialize_funct_h5
+from executorlib.standalone.serialize import serialize_funct
 
 
 def execute_tasks(
@@ -132,7 +132,7 @@ def _execute_task_with_cache(
     """
     from executorlib.task_scheduler.file.hdf import dump, get_output
 
-    task_key, data_dict = serialize_funct_h5(
+    task_key, data_dict = serialize_funct(
         fn=task_dict["fn"],
         fn_args=task_dict["args"],
         fn_kwargs=task_dict["kwargs"],

--- a/tests/test_cache_backend_execute.py
+++ b/tests/test_cache_backend_execute.py
@@ -8,7 +8,7 @@ try:
     from executorlib.task_scheduler.file.backend import backend_execute_task_in_file
     from executorlib.task_scheduler.file.shared import _check_task_output, FutureItem
     from executorlib.task_scheduler.file.hdf import dump, get_runtime
-    from executorlib.standalone.serialize import serialize_funct_h5
+    from executorlib.standalone.serialize import serialize_funct
 
     skip_h5io_test = False
 except ImportError:
@@ -30,7 +30,7 @@ class TestSharedFunctions(unittest.TestCase):
     def test_execute_function_mixed(self):
         cache_directory = os.path.abspath("executorlib_cache")
         os.makedirs(cache_directory, exist_ok=True)
-        task_key, data_dict = serialize_funct_h5(
+        task_key, data_dict = serialize_funct(
             fn=my_funct,
             fn_args=[1],
             fn_kwargs={"b": 2},
@@ -58,7 +58,7 @@ class TestSharedFunctions(unittest.TestCase):
     def test_execute_function_args(self):
         cache_directory = os.path.abspath("executorlib_cache")
         os.makedirs(cache_directory, exist_ok=True)
-        task_key, data_dict = serialize_funct_h5(
+        task_key, data_dict = serialize_funct(
             fn=my_funct,
             fn_args=[1, 2],
             fn_kwargs=None,
@@ -86,7 +86,7 @@ class TestSharedFunctions(unittest.TestCase):
     def test_execute_function_kwargs(self):
         cache_directory = os.path.abspath("executorlib_cache")
         os.makedirs(cache_directory, exist_ok=True)
-        task_key, data_dict = serialize_funct_h5(
+        task_key, data_dict = serialize_funct(
             fn=my_funct,
             fn_args=None,
             fn_kwargs={"a": 1, "b": 2},
@@ -114,7 +114,7 @@ class TestSharedFunctions(unittest.TestCase):
     def test_execute_function_error(self):
         cache_directory = os.path.abspath("executorlib_cache")
         os.makedirs(cache_directory, exist_ok=True)
-        task_key, data_dict = serialize_funct_h5(
+        task_key, data_dict = serialize_funct(
             fn=get_error,
             fn_args=[],
             fn_kwargs={"a": 1},


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Renamed a serialization function for consistency across the application. All related imports and function calls have been updated to use the new name.

* **Tests**
  * Updated test cases to use the renamed serialization function. No changes to test logic or outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->