### PR TITLE
Extend the features supported by get_cache_execute_command()

### DIFF
--- a/executorlib/standalone/command.py
+++ b/executorlib/standalone/command.py
@@ -65,9 +65,13 @@ def get_cache_execute_command(
             if pmi_mode is not None:
                 flux_command += ["-o", "pmi=" + pmi_mode]
             if openmpi_oversubscribe:
-                raise ValueError("The option openmpi_oversubscribe is not available with the flux backend.")
+                raise ValueError(
+                    "The option openmpi_oversubscribe is not available with the flux backend."
+                )
             if exclusive:
-                raise ValueError("The option exclusive is not available with the flux backend.")
+                raise ValueError(
+                    "The option exclusive is not available with the flux backend."
+                )
             command_lst = (
                 flux_command
                 + ["-n", str(cores)]

--- a/executorlib/task_scheduler/file/shared.py
+++ b/executorlib/task_scheduler/file/shared.py
@@ -156,6 +156,8 @@ def execute_tasks_h5(
                             file_name=file_name,
                             cores=task_resource_dict["cores"],
                             backend=backend,
+                            exclusive=task_resource_dict.get("exclusive", False),
+                            openmpi_oversubscribe=task_resource_dict.get("openmpi_oversubscribe", False),
                             pmi_mode=pmi_mode,
                         ),
                         file_name=file_name,

--- a/executorlib/task_scheduler/file/shared.py
+++ b/executorlib/task_scheduler/file/shared.py
@@ -157,7 +157,9 @@ def execute_tasks_h5(
                             cores=task_resource_dict["cores"],
                             backend=backend,
                             exclusive=task_resource_dict.get("exclusive", False),
-                            openmpi_oversubscribe=task_resource_dict.get("openmpi_oversubscribe", False),
+                            openmpi_oversubscribe=task_resource_dict.get(
+                                "openmpi_oversubscribe", False
+                            ),
                             pmi_mode=pmi_mode,
                         ),
                         file_name=file_name,

--- a/executorlib/task_scheduler/file/task_scheduler.py
+++ b/executorlib/task_scheduler/file/task_scheduler.py
@@ -56,6 +56,8 @@ class FileTaskScheduler(TaskSchedulerBase):
             "cores": 1,
             "cwd": None,
             "cache_directory": "executorlib_cache",
+            "exclusive": False,
+            "openmpi_oversubscribe": False,
         }
         if resource_dict is None:
             resource_dict = {}

--- a/tests/test_standalone_command.py
+++ b/tests/test_standalone_command.py
@@ -51,14 +51,16 @@ class TestCommands(unittest.TestCase):
         self.assertEqual(output[3], sys.executable)
         self.assertEqual(output[4].split(os.sep)[-1], "cache_parallel.py")
         self.assertEqual(output[5], file_name)
-        output = get_cache_execute_command(cores=2, file_name=file_name, backend="slurm", pmi_mode="pmi2")
+        output = get_cache_execute_command(cores=2, file_name=file_name, backend="slurm", pmi_mode="pmi2", openmpi_oversubscribe=True, exclusive=True)
         self.assertEqual(output[0], "srun")
         self.assertEqual(output[1], "-n")
         self.assertEqual(output[2], str(2))
         self.assertEqual(output[3], "--mpi=pmi2")
-        self.assertEqual(output[4], sys.executable)
-        self.assertEqual(output[5].split(os.sep)[-1], "cache_parallel.py")
-        self.assertEqual(output[6], file_name)
+        self.assertEqual(output[4], "--oversubscribe")
+        self.assertEqual(output[5], "--exact")
+        self.assertEqual(output[6], sys.executable)
+        self.assertEqual(output[7].split(os.sep)[-1], "cache_parallel.py")
+        self.assertEqual(output[8], file_name)
         output = get_cache_execute_command(cores=2, file_name=file_name, backend="slurm")
         self.assertEqual(output[0], "srun")
         self.assertEqual(output[1], "-n")
@@ -86,3 +88,7 @@ class TestCommands(unittest.TestCase):
         self.assertEqual(output[8], file_name)
         with self.assertRaises(ValueError):
             get_cache_execute_command(cores=2, file_name=file_name, backend="test")
+        with self.assertRaises(ValueError):
+            get_cache_execute_command(cores=2, file_name=file_name, backend="flux", openmpi_oversubscribe=True)
+        with self.assertRaises(ValueError):
+            get_cache_execute_command(cores=2, file_name=file_name, backend="flux", exclusive=True)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two execution options: "exclusive" and "OpenMPI oversubscribe" that, when used with Slurm, map to --exact and --oversubscribe respectively.
  * These options are disallowed for Flux and will produce a clear error if provided.
  * Existing execution behavior (including PMI handling and other backends) remains unchanged.

* **Documentation**
  * Updated parameter descriptions to document the new options and defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->