### PR TITLE
Communication: Simplify if statement for interface bootup

### DIFF
--- a/executorlib/standalone/interactive/communication.py
+++ b/executorlib/standalone/interactive/communication.py
@@ -159,9 +159,7 @@ def interface_bootup(
     Returns:
          executorlib.shared.communication.SocketInterface: socket interface for zmq communication
     """
-    if hostname_localhost is None and sys.platform == "darwin":
-        hostname_localhost = True
-    elif hostname_localhost is None:
+    if hostname_localhost is None and sys.platform != "darwin":
         hostname_localhost = False
     if not hostname_localhost:
         command_lst += [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated default network binding to use the machine’s hostname instead of localhost, including on macOS. This makes host-based addressing the default across platforms, improving connectivity and access from other devices.
  * Enhances consistency in how the application determines and applies the host option during startup, reducing cases where services were only reachable via localhost.
  * No changes to public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->