### PR TITLE
Keep interface alive after crash

### DIFF
--- a/executorlib/task_scheduler/interactive/shared.py
+++ b/executorlib/task_scheduler/interactive/shared.py
@@ -74,7 +74,6 @@ def _execute_task_without_cache(
     try:
         future_obj.set_result(interface.send_and_receive_dict(input_dict=task_dict))
     except Exception as thread_exception:
-        interface.shutdown(wait=True)
         future_obj.set_exception(exception=thread_exception)
 
 
@@ -116,7 +115,6 @@ def _execute_task_with_cache(
             dump(file_name=file_name, data_dict=data_dict)
             future_obj.set_result(result)
         except Exception as thread_exception:
-            interface.shutdown(wait=True)
             future_obj.set_exception(exception=thread_exception)
     else:
         _, _, result = get_output(file_name=file_name)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Interactive tasks no longer shut down the interface when an error occurs during message exchange. Errors are now reported to the task while keeping the interface running, reducing unexpected session terminations, preserving state, and enabling smoother recovery and retries. Users should experience fewer interruptions and faster subsequent operations after transient failures, improving overall workflow stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->