### PR TITLE
Extend SLURM time out

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -274,7 +274,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: koesterlab/setup-slurm-action@v1
-      timeout-minutes: 5
+      timeout-minutes: 10
     - name: ubnuntu install
       run: sudo apt install -y mpich
     - uses: conda-incubator/setup-miniconda@v3


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Continuous integration workflow updated: increased the timeout for the SLURM setup step in the unittest job from 5 to 10 minutes. This helps accommodate slower runners and stabilizes automated test execution in certain environments.
  - No changes to application behavior or public APIs. End users will not see any interface or feature differences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->