### PR TITLE
map(): Evaluate generator within with-statement

### DIFF
--- a/tests/test_fluxjobexecutor.py
+++ b/tests/test_fluxjobexecutor.py
@@ -104,9 +104,9 @@ class TestFluxBackend(unittest.TestCase):
             block_allocation=True,
             pmi_mode=pmi,
         ) as p:
-            output = p.map(mpi_funct, [1, 2, 3])
+            output = list(p.map(mpi_funct, [1, 2, 3]))
         self.assertEqual(
-            list(output),
+            output,
             [[(1, 2, 0), (1, 2, 1)], [(2, 2, 0), (2, 2, 1)], [(3, 2, 0), (3, 2, 1)]],
         )
 
@@ -122,9 +122,9 @@ class TestFluxBackend(unittest.TestCase):
             block_allocation=True,
             flux_log_files=True,
         ) as p:
-            output = p.map(calc, [1, 2, 3])
+            output = list(p.map(calc, [1, 2, 3]))
         self.assertEqual(
-            list(output),
+            output,
             [1, 2, 3],
         )
         self.assertTrue(os.path.exists(file_stdout))
@@ -142,9 +142,9 @@ class TestFluxBackend(unittest.TestCase):
             block_allocation=True,
             flux_log_files=True,
         ) as p:
-            output = p.map(calc, [1, 2, 3])
+            output = list(p.map(calc, [1, 2, 3]))
         self.assertEqual(
-            list(output),
+            output,
             [1, 2, 3],
         )
         self.assertTrue(os.path.exists(file_stdout))

--- a/tests/test_fluxpythonspawner.py
+++ b/tests/test_fluxpythonspawner.py
@@ -99,9 +99,9 @@ class TestFlux(unittest.TestCase):
             },
             spawner=FluxPythonSpawner,
         ) as p:
-            output = p.map(mpi_funct, [1, 2, 3])
+            output = list(p.map(mpi_funct, [1, 2, 3]))
         self.assertEqual(
-            list(output),
+            output,
             [[(1, 2, 0), (1, 2, 1)], [(2, 2, 0), (2, 2, 1)], [(3, 2, 0), (3, 2, 1)]],
         )
 

--- a/tests/test_mpiexecspawner.py
+++ b/tests/test_mpiexecspawner.py
@@ -323,8 +323,8 @@ class TestFuturePool(unittest.TestCase):
             executor_kwargs={"cores": 1},
             spawner=MpiExecSpawner,
         ) as p:
-            output = p.map(calc_array, [1, 2, 3])
-        self.assertEqual(list(output), [np.array(1), np.array(4), np.array(9)])
+            output = list(p.map(calc_array, [1, 2, 3]))
+        self.assertEqual(output, [np.array(1), np.array(4), np.array(9)])
 
     def test_executor_exception(self):
         with self.assertRaises(RuntimeError):
@@ -430,9 +430,9 @@ class TestFuturePool(unittest.TestCase):
             executor_kwargs={"cores": 2},
             spawner=MpiExecSpawner,
         ) as p:
-            output = p.map(mpi_funct, [1, 2, 3])
+            output = list(p.map(mpi_funct, [1, 2, 3]))
         self.assertEqual(
-            list(output),
+            output,
             [[(1, 2, 0), (1, 2, 1)], [(2, 2, 0), (2, 2, 1)], [(3, 2, 0), (3, 2, 1)]],
         )
 

--- a/tests/test_singlenodeexecutor_mpi.py
+++ b/tests/test_singlenodeexecutor_mpi.py
@@ -119,9 +119,9 @@ class TestWorkingDirectory(unittest.TestCase):
             resource_dict={"cores": 1, "cwd": dirname},
             block_allocation=True,
         ) as p:
-            output = p.map(calc, [1, 2, 3])
+            output = list(p.map(calc, [1, 2, 3]))
         self.assertEqual(
-            list(output),
+            output,
             [1, 2, 3],
         )
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Standardized test behavior by eagerly materializing map results, simplifying assertions across multiple executor and spawner scenarios (serial, multi-core, working directory, and single-node cases).
  - Improves test consistency and readability without altering functional outcomes.
  - Confirms no changes to public APIs or runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->