### PR TITLE
Update pyzmq to 27.1.0

### DIFF
--- a/.ci_support/environment-docs.yml
+++ b/.ci_support/environment-docs.yml
@@ -1,18 +1,18 @@
 channels:
 - conda-forge
 dependencies:
+- flux-core
 - hatchling
 - hatch-vcs
-- nbsphinx
-- sphinx
-- sphinx_rtd_theme
 - myst-parser
+- nbsphinx
 - numpy
 - openmpi
+- sphinx
+- sphinx_rtd_theme
 - cloudpickle =3.1.1
-- mpi4py =4.0.1
-- pyzmq =27.1.0
-- flux-core
-- jupyter-book =1.0.0
 - h5py =3.14.0
+- jupyter-book =1.0.0
+- mpi4py =4.0.1
 - python =3.12
+- pyzmq =27.1.0

--- a/.ci_support/environment-docs.yml
+++ b/.ci_support/environment-docs.yml
@@ -11,7 +11,7 @@ dependencies:
 - openmpi
 - cloudpickle =3.1.1
 - mpi4py =4.0.1
-- pyzmq =27.0.2
+- pyzmq =27.1.0
 - flux-core
 - jupyter-book =1.0.0
 - h5py =3.14.0

--- a/.ci_support/environment-integration.yml
+++ b/.ci_support/environment-integration.yml
@@ -1,22 +1,22 @@
 channels:
 - conda-forge
 dependencies:
+- h5py
 - jupyter
-- papermill
+- mpi4py
 - numpy
 - openmpi
+- papermill
+- atomistics =0.2.5
 - cloudpickle =3.1.1
-- mpi4py
-- pyzmq =27.0.2
 - flux-core =0.59.0
+- gpaw =24.6.0
 - hatchling =1.27.0
 - hatch-vcs =0.5.0
-- h5py
+- ipython =9.0.2
 - matplotlib =3.10.3
 - networkx =3.4.2
 - pygraphviz =1.14
 - pysqa =0.3.1
-- ipython =9.0.2
-- atomistics =0.2.5
+- pyzmq =27.1.0
 - qe =7.4
-- gpaw =24.6.0

--- a/.ci_support/environment-mini.yml
+++ b/.ci_support/environment-mini.yml
@@ -4,6 +4,6 @@ dependencies:
 - python
 - numpy
 - cloudpickle =3.1.0
-- pyzmq =27.0.2
 - hatchling =1.27.0
 - hatch-vcs =0.5.0
+- pyzmq =27.1.0

--- a/.ci_support/environment-mpich.yml
+++ b/.ci_support/environment-mpich.yml
@@ -5,12 +5,12 @@ dependencies:
 - numpy
 - mpich
 - cloudpickle =3.1.1
-- mpi4py =4.0.1
-- pyzmq =27.0.2
 - h5py =3.14.0
-- networkx =3.4.2
-- pygraphviz =1.14
-- ipython =9.0.2
-- pysqa =0.3.1
 - hatchling =1.27.0
 - hatch-vcs =0.5.0
+- ipython =9.0.2
+- mpi4py =4.0.1
+- networkx =3.4.2
+- pygraphviz =1.14
+- pysqa =0.3.1
+- pyzmq =27.1.0

--- a/.ci_support/environment-openmpi.yml
+++ b/.ci_support/environment-openmpi.yml
@@ -5,12 +5,12 @@ dependencies:
 - numpy
 - openmpi
 - cloudpickle =3.1.1
-- mpi4py =4.0.1
-- pyzmq =27.0.2
 - h5py =3.14.0
+- hatchling =1.27.0
+- hatch-vcs =0.5.0
+- ipython =9.0.2
+- mpi4py =4.0.1
 - networkx =3.4.2
 - pygraphviz =1.14
 - pysqa =0.3.1
-- ipython =9.0.2
-- hatchling =1.27.0
-- hatch-vcs =0.5.0
+- pyzmq =27.1.0

--- a/.ci_support/environment-win.yml
+++ b/.ci_support/environment-win.yml
@@ -5,11 +5,11 @@ dependencies:
 - numpy
 - msmpi
 - cloudpickle =3.1.1
-- mpi4py =4.0.1
-- pyzmq =27.0.2
 - h5py =3.14.0
-- networkx =3.4.2
-- pygraphviz =1.14
-- ipython =9.0.2
 - hatchling =1.27.0
 - hatch-vcs =0.5.0
+- ipython =9.0.2
+- mpi4py =4.0.1
+- networkx =3.4.2
+- pygraphviz =1.14
+- pyzmq =27.1.0

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -5,15 +5,15 @@ dependencies:
 - numpy
 - openmpi
 - cloudpickle =3.1.1
-- mpi4py =4.0.1
-- pyzmq =27.0.2
 - flux-core =0.59.0
 - flux-pmix =0.5.0
 - hatchling =1.27.0
 - hatch-vcs =0.5.0
 - h5py =3.12.1
+- ipython =9.0.2
 - matplotlib =3.10.0
+- mpi4py =4.0.1
 - networkx =3.4.2
 - pygraphviz =1.14
 - pysqa =0.3.1
-- ipython =9.0.2
+- pyzmq =27.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 ]
 dependencies = [
     "cloudpickle==3.1.1",
-    "pyzmq==27.0.2",
+    "pyzmq==27.1.0",
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
     "hatchling==1.27.0",
     "hatch-vcs==0.5.0",
     "cloudpickle==3.1.1",
-    "pyzmq==27.0.2",
+    "pyzmq==27.1.0",
 ]
 build-backend = "hatchling.build"
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated PyZMQ to 27.1.0 across environments and packaging for consistency.
  - Refreshed integration environments: added MPI, IPython, HDF5, GPAW, and Papermill; removed unused tooling to streamline builds.
  - Aligned Binder and CI environments for reproducible setups.
  - Added flux-core to dependencies.

- Documentation
  - Restored documentation build stack (Sphinx, nbsphinx, Read the Docs theme) to ensure docs build reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->