### PR TITLE
Downgrade atomistics to 0.2.5

### DIFF
--- a/.ci_support/environment-integration.yml
+++ b/.ci_support/environment-integration.yml
@@ -7,7 +7,7 @@ dependencies:
 - numpy
 - openmpi
 - papermill
-- atomistics =0.3.0
+- atomistics =0.2.5
 - cloudpickle =3.1.1
 - flux-core =0.59.0
 - gpaw =24.6.0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the atomistics package version in the integration environment to 0.2.5.
  * No other dependencies were changed.
  * This update impacts build/integration configuration only and does not affect application features or behavior.
  * No user-facing changes.
  * No updates required for documentation or tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->