### PR TITLE
[Fix] Accept benchmarks when block_allocation is faster than the processpoolexecutor

### DIFF
--- a/tests/benchmark/test_results.py
+++ b/tests/benchmark/test_results.py
@@ -6,7 +6,7 @@ class TestResults(unittest.TestCase):
         with open("timing.log") as f:
             content = f.readlines()
         timing_dict = {l.split()[0]: float(l.split()[1]) for l in content}
-        self.assertEqual(min(timing_dict, key=timing_dict.get), "process")
+        self.assertTrue(min(timing_dict, key=timing_dict.get) in ["process", "block_allocation"])
         self.assertEqual(max(timing_dict, key=timing_dict.get), "static")
         self.assertTrue(timing_dict["process"] < timing_dict["executorlib"])
         self.assertTrue(timing_dict["block_allocation"] < timing_dict["process"] * 1.1)


### PR DESCRIPTION
It's not a bug it is just a fix to improve the continuous integration stability. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated benchmark timing test expectations to accept multiple valid timing entry configurations as minimum values, increasing test flexibility while preserving all other validation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->