### PR TITLE
Improve unit test coverage for resource validation and pydantic fallback

### DIFF
--- a/src/executorlib/standalone/validate.py
+++ b/src/executorlib/standalone/validate.py
@@ -33,7 +33,8 @@ def validate_resource_dict_with_optional_keys(resource_dict: dict) -> None:
         key: value for key, value in resource_dict.items() if key in accepted_keys
     }
     _ = ResourceDictValidation(**validate_dict)
-    warnings.warn(
-        f"The following keys are not recognized and cannot be validated: {optional_lst}",
-        stacklevel=2,
-    )
+    if len(optional_lst) > 0:
+        warnings.warn(
+            f"The following keys are not recognized and cannot be validated: {optional_lst}",
+            stacklevel=2,
+        )

--- a/tests/unit/standalone/test_fallback.py
+++ b/tests/unit/standalone/test_fallback.py
@@ -1,0 +1,40 @@
+import unittest
+from unittest.mock import patch
+import sys
+import importlib
+
+class TestFallback(unittest.TestCase):
+    def test_fallback_import(self):
+        # Mock pydantic to be missing
+        with patch.dict('sys.modules', {'pydantic': None}):
+            # We need to reload the modules that do the try-except import
+            if 'executorlib.standalone.validate' in sys.modules:
+                del sys.modules['executorlib.standalone.validate']
+            if 'executorlib.executor.single' in sys.modules:
+                del sys.modules['executorlib.executor.single']
+
+            import executorlib.executor.single
+            importlib.reload(executorlib.executor.single)
+
+            from executorlib.executor.single import validate_resource_dict
+
+            # Check that it is the fallback function (which is just a pass)
+            # The fallback comes from executorlib.task_scheduler.base
+            import inspect
+            source_file = inspect.getfile(validate_resource_dict)
+            self.assertTrue(source_file.endswith('task_scheduler/base.py'))
+
+            # Verify it works without crashing
+            self.assertIsNone(validate_resource_dict({"any": "thing"}))
+
+    def tearDown(self):
+        # Clean up after ourselves to not affect other tests
+        for mod in ['executorlib.standalone.validate', 'executorlib.executor.single', 'pydantic']:
+            if mod in sys.modules:
+                # We don't want to actually delete pydantic if it was there before,
+                # but we want to make sure the next import gets the real one.
+                # Actually patch.dict handles pydantic.
+                pass
+        # Reloading single.py to restore normal state
+        if 'executorlib.executor.single' in sys.modules:
+            importlib.reload(sys.modules['executorlib.executor.single'])

--- a/tests/unit/standalone/test_validate.py
+++ b/tests/unit/standalone/test_validate.py
@@ -1,0 +1,41 @@
+import unittest
+import warnings
+from executorlib.executor.single import (
+    validate_resource_dict,
+    validate_resource_dict_with_optional_keys
+)
+
+try:
+    from pydantic import ValidationError
+    pydantic_installed = True
+except ImportError:
+    pydantic_installed = False
+
+class TestValidate(unittest.TestCase):
+    def test_validate_resource_dict(self):
+        self.assertIsNone(validate_resource_dict(resource_dict={}))
+        self.assertIsNone(validate_resource_dict(resource_dict={"cores": 1}))
+        if pydantic_installed:
+            with self.assertRaises(ValidationError):
+                validate_resource_dict(resource_dict={"cores": "a"})
+
+    def test_validate_resource_dict_with_optional_keys(self):
+        # Test valid keys (should not warn)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            validate_resource_dict_with_optional_keys(resource_dict={"cores": 1})
+            self.assertEqual(len([item for item in w if issubclass(item.category, UserWarning)]), 0)
+
+        # Test unknown keys
+        if pydantic_installed:
+            with self.assertWarns(UserWarning):
+                validate_resource_dict_with_optional_keys(resource_dict={"unknown_key": 1})
+            with self.assertRaises(ValidationError):
+                # Valid key but wrong type
+                validate_resource_dict_with_optional_keys(resource_dict={"cores": "a"})
+        else:
+            # Should not warn even with unknown keys if pydantic is missing (current fallback behavior)
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                validate_resource_dict_with_optional_keys(resource_dict={"unknown_key": 1})
+                self.assertEqual(len([item for item in w if issubclass(item.category, UserWarning)]), 0)


### PR DESCRIPTION
Extended unit tests to improve coverage of newly added code, specifically focusing on resource validation. Fixed a bug in the validation logic and added comprehensive tests for both standard validation (using `pydantic`) and the fallback mechanism (when `pydantic` is missing).

---
*PR created automatically by Jules for task [5296512229740640906](https://jules.google.com/task/5296512229740640906) started by @jan-janssen*