### PR TITLE
[Documentation] Add test coverage guidance for integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ as hierarchical job scheduler within the allocations.
   * [Filesystem Usage](https://executorlib.readthedocs.io/en/latest/trouble_shooting.html#filesystem-usage)
   * [Firewall Issues](https://executorlib.readthedocs.io/en/latest/trouble_shooting.html#firewall-issues)
   * [Message Passing Interface](https://executorlib.readthedocs.io/en/latest/trouble_shooting.html#message-passing-interface)
+  * [Test Coverage for Integration Tests](https://executorlib.readthedocs.io/en/latest/trouble_shooting.html#test-coverage-for-integration-tests)
   * [Python Version](https://executorlib.readthedocs.io/en/latest/trouble_shooting.html#python-version)
   * [Resource Dictionary](https://executorlib.readthedocs.io/en/latest/trouble_shooting.html#resource-dictionary)
   * [SSH Connection](https://executorlib.readthedocs.io/en/latest/trouble_shooting.html#ssh-connection)

--- a/docs/trouble_shooting.md
+++ b/docs/trouble_shooting.md
@@ -31,6 +31,25 @@ Typical error messages related to missing dependencies are `ModuleNotFoundError`
 * `ModuleNotFoundError: No module named 'h5py'` - Install [h5py](https://www.h5py.org/) as explained in the [Caching](https://executorlib.readthedocs.io/en/latest/installation.html#caching) section of the installation. 
 * `ModuleNotFoundError: No module named 'networkx'` - Install [networkx](https://networkx.org/) as explained in the [Visualisation](https://executorlib.readthedocs.io/en/latest/installation.html#visualisation) section of the installation.
 
+## Test Coverage for Integration Tests
+When Python functions are executed with executorlib, they run in subprocesses started via `sys.executable`. As a result, `coverage run`
+only tracks the main test process by default and can miss function execution inside executorlib workers.
+
+To collect coverage from both the main process and executorlib subprocesses, enable the subprocess patch in your project configuration:
+```toml
+[tool.coverage.run]
+patch = ["subprocess"]
+```
+
+Then execute:
+```bash
+coverage run -m unittest discover
+coverage combine
+coverage report
+```
+
+The `coverage combine` command merges the data from the main process and subprocesses.
+
 ## Python Version 
 Executorlib supports all current Python version ranging from 3.9 to 3.13. Still some of the dependencies and especially 
 the [flux](http://flux-framework.org) job scheduler are currently limited to Python 3.12 and below. Consequently for high


### PR DESCRIPTION
Integrates the explanation for collecting code coverage from executorlib subprocesses into the documentation, as discussed in issue #965. Updated `docs/trouble_shooting.md` with instructions and `README.md` with a link to the new section.

---
*PR created automatically by Jules for task [13437585165890297203](https://jules.google.com/task/13437585165890297203) started by @jan-janssen*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added troubleshooting guide for configuring test coverage in subprocess-based environments, including configuration steps and reporting commands.
  * Updated documentation navigation with link to new coverage troubleshooting section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->