### PR TITLE
Remove snakemake from comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ executorlib is the lightest path to take *existing* Python functions and scale t
 library [Executor interface](https://docs.python.org/3/library/concurrent.futures.html#executor-objects) you already
 know, rather than asking you to adopt a new data, actor, or workflow model.
 
-| | executorlib | `concurrent.futures` | [Dask](https://www.dask.org) | [Parsl](https://parsl-project.org) | [Ray](https://www.ray.io) |
+| | executorlib | [Concurrent futures](https://docs.python.org/3/library/concurrent.futures.html) | [Dask](https://www.dask.org) | [Parsl](https://parsl-project.org) | [Ray](https://www.ray.io) |
 |---|---|---|---|---|---|
 | Drop-in `Executor` API | ✅ | ✅ | ⚠️ | ⚠️  | ❌ |
 | Per-call resource assignment | ✅ | ❌ | ⚠️ | ✅ | ✅ |

--- a/README.md
+++ b/README.md
@@ -26,14 +26,14 @@ executorlib is the lightest path to take *existing* Python functions and scale t
 library [Executor interface](https://docs.python.org/3/library/concurrent.futures.html#executor-objects) you already
 know, rather than asking you to adopt a new data, actor, or workflow model.
 
-| | executorlib | `concurrent.futures` | [Dask](https://www.dask.org) | [Parsl](https://parsl-project.org) | [Ray](https://www.ray.io) | [Snakemake](https://snakemake.github.io) |
-|---|---|---|---|---|---|---|
-| Drop-in `Executor` API | ✅ | ✅ | ⚠️ | ❌ | ❌ | ❌ |
-| Per-call resource assignment | ✅ | ❌ | ⚠️ | ✅ | ✅ | ✅ |
-| Native HPC scheduler (SLURM/flux) | ✅ | ❌ | ⚠️ | ✅ | ⚠️ | ✅ |
-| MPI-parallel functions | ✅ | ❌ | ⚠️ | ✅ | ⚠️ | ⚠️ |
-| Caching of results | ✅ | ❌ | ⚠️ | ✅ | ❌ | ✅ |
-| Setup / learning overhead | Low | Very low | Medium | Medium | Medium | High |
+| | executorlib | `concurrent.futures` | [Dask](https://www.dask.org) | [Parsl](https://parsl-project.org) | [Ray](https://www.ray.io) |
+|---|---|---|---|---|---|
+| Drop-in `Executor` API | ✅ | ✅ | ⚠️ | ❌ | ❌ |
+| Per-call resource assignment | ✅ | ❌ | ⚠️ | ✅ | ✅ |
+| Native HPC scheduler (SLURM/flux) | ✅ | ❌ | ⚠️ | ✅ | ⚠️ |
+| MPI-parallel functions | ✅ | ❌ | ⚠️ | ✅ | ⚠️ |
+| Caching of results | ✅ | ❌ | ⚠️ | ✅ | ❌ |
+| Setup / learning overhead | Low | Very low | Medium | Medium | Medium |
 
 ✅ first-class · ⚠️ possible via add-on/config · ❌ not supported. See the full
 [comparison: when to use which](https://executorlib.readthedocs.io/en/latest/comparison.html) for honest guidance on
@@ -156,7 +156,6 @@ as hierarchical job scheduler within the allocations.
   * [Dask](https://executorlib.readthedocs.io/en/latest/comparison.html#dask)
   * [Parsl](https://executorlib.readthedocs.io/en/latest/comparison.html#parsl)
   * [Ray](https://executorlib.readthedocs.io/en/latest/comparison.html#ray)
-  * [Snakemake](https://executorlib.readthedocs.io/en/latest/comparison.html#snakemake)
   * [Choose executorlib when](https://executorlib.readthedocs.io/en/latest/comparison.html#choose-executorlib-when)
 * [Single Node Executor](https://executorlib.readthedocs.io/en/latest/1-single-node.html)
   * [Basic Functionality](https://executorlib.readthedocs.io/en/latest/1-single-node.html#basic-functionality)

--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ know, rather than asking you to adopt a new data, actor, or workflow model.
 
 | | executorlib | `concurrent.futures` | [Dask](https://www.dask.org) | [Parsl](https://parsl-project.org) | [Ray](https://www.ray.io) |
 |---|---|---|---|---|---|
-| Drop-in `Executor` API | ✅ | ✅ | ⚠️ | ❌ | ❌ |
+| Drop-in `Executor` API | ✅ | ✅ | ⚠️ | ⚠️  | ❌ |
 | Per-call resource assignment | ✅ | ❌ | ⚠️ | ✅ | ✅ |
 | Native HPC scheduler (SLURM/flux) | ✅ | ❌ | ⚠️ | ✅ | ⚠️ |
-| MPI-parallel functions | ✅ | ❌ | ⚠️ | ✅ | ⚠️ |
+| MPI-parallel functions | ✅ | ❌ | ⚠️ | ⚠️ | ⚠️ |
 | Caching of results | ✅ | ❌ | ⚠️ | ✅ | ❌ |
 | Setup / learning overhead | Low | Very low | Medium | Medium | Medium |
 

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -13,10 +13,10 @@ alternative is the better choice.
 
 | | executorlib | `concurrent.futures` | Dask | Parsl | Ray |
 |---|---|---|---|---|---|
-| Drop-in `Executor` API | ✅ | ✅ | ⚠️ | ❌ | ❌ |
+| Drop-in `Executor` API | ✅ | ✅ | ⚠️ | ⚠️  | ❌ |
 | Per-call resource assignment | ✅ | ❌ | ⚠️ | ✅ | ✅ |
 | Native HPC scheduler (SLURM/flux) | ✅ | ❌ | ⚠️ | ✅ | ⚠️ |
-| MPI-parallel functions | ✅ | ❌ | ⚠️ | ✅ | ⚠️ |
+| MPI-parallel functions | ✅ | ❌ | ⚠️ | ⚠️ | ⚠️ |
 | Caching of results | ✅ | ❌ | ⚠️ | ✅ | ❌ |
 | Setup / learning overhead | Low | Very low | Medium | Medium | Medium |
 

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -11,7 +11,7 @@ alternative is the better choice.
 
 ## At a glance
 
-| | executorlib | `concurrent.futures` | Dask | Parsl | Ray |
+| | executorlib | Concurrent futures | Dask | Parsl | Ray |
 |---|---|---|---|---|---|
 | Drop-in `Executor` API | ✅ | ✅ | ⚠️ | ⚠️  | ❌ |
 | Per-call resource assignment | ✅ | ❌ | ⚠️ | ✅ | ✅ |

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -11,14 +11,14 @@ alternative is the better choice.
 
 ## At a glance
 
-| | executorlib | `concurrent.futures` | Dask | Parsl | Ray | Snakemake |
-|---|---|---|---|---|---|---|
-| Drop-in `Executor` API | ✅ | ✅ | ⚠️ | ❌ | ❌ | ❌ |
-| Per-call resource assignment | ✅ | ❌ | ⚠️ | ✅ | ✅ | ✅ |
-| Native HPC scheduler (SLURM/flux) | ✅ | ❌ | ⚠️ | ✅ | ⚠️ | ✅ |
-| MPI-parallel functions | ✅ | ❌ | ⚠️ | ✅ | ⚠️ | ⚠️ |
-| Caching of results | ✅ | ❌ | ⚠️ | ✅ | ❌ | ✅ |
-| Setup / learning overhead | Low | Very low | Medium | Medium | Medium | High |
+| | executorlib | `concurrent.futures` | Dask | Parsl | Ray |
+|---|---|---|---|---|---|
+| Drop-in `Executor` API | ✅ | ✅ | ⚠️ | ❌ | ❌ |
+| Per-call resource assignment | ✅ | ❌ | ⚠️ | ✅ | ✅ |
+| Native HPC scheduler (SLURM/flux) | ✅ | ❌ | ⚠️ | ✅ | ⚠️ |
+| MPI-parallel functions | ✅ | ❌ | ⚠️ | ✅ | ⚠️ |
+| Caching of results | ✅ | ❌ | ⚠️ | ✅ | ❌ |
+| Setup / learning overhead | Low | Very low | Medium | Medium | Medium |
 
 ✅ first-class · ⚠️ possible via an add-on or extra configuration · ❌ not supported.
 
@@ -57,14 +57,6 @@ scheduler integration is via cluster launchers rather than native SLURM/flux.
 
 **Use Ray instead when** you need long-lived stateful actors, an AI/ML ecosystem, or a distributed-object model — and you
 are willing to write code in Ray's paradigm.
-
-## [Snakemake](https://snakemake.github.io)
-
-Snakemake is a file-oriented workflow manager: you declare rules with inputs/outputs and it builds a dependency graph,
-with strong HPC support and file-based caching. It is a workflow DSL, not a drop-in way to parallelize Python functions.
-
-**Use Snakemake instead when** your pipeline is naturally expressed as files transformed by rules, and you want
-reproducible, file-driven workflow management rather than in-process Python futures.
 
 ## Choose executorlib when
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated comparison tables to better focus on key frameworks: executorlib, concurrent.futures, Dask, Parsl, and Ray
  * Clarified Parsl's support status for Drop-in Executor API to provide more accurate information
  * Streamlined documentation by removing Snakemake and simplifying the comparison structure for improved navigation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pyiron/executorlib/pull/994?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->