### PR TITLE
[Bug] Ignore duplicate entries in cache

### DIFF
--- a/src/executorlib/standalone/hdf.py
+++ b/src/executorlib/standalone/hdf.py
@@ -33,9 +33,10 @@ def dump(file_name: Optional[str], data_dict: dict) -> None:
         os.makedirs(os.path.dirname(file_name_abs), exist_ok=True)
         with h5py.File(file_name_abs, "a") as fname:
             for data_key, data_value in data_dict.items():
-                if data_key in group_dict:
+                path = "/" + group_dict[data_key]
+                if data_key in group_dict and path not in fname:
                     fname.create_dataset(
-                        name="/" + group_dict[data_key],
+                        name=path,
                         data=np.void(cloudpickle.dumps(data_value)),
                     )
 

--- a/src/executorlib/standalone/hdf.py
+++ b/src/executorlib/standalone/hdf.py
@@ -1,5 +1,5 @@
-import os
 import contextlib
+import os
 from concurrent.futures import Future
 from time import sleep
 from typing import Any, Optional

--- a/src/executorlib/standalone/hdf.py
+++ b/src/executorlib/standalone/hdf.py
@@ -1,4 +1,5 @@
 import os
+import contextlib
 from concurrent.futures import Future
 from time import sleep
 from typing import Any, Optional
@@ -33,11 +34,12 @@ def dump(file_name: Optional[str], data_dict: dict) -> None:
         os.makedirs(os.path.dirname(file_name_abs), exist_ok=True)
         with h5py.File(file_name_abs, "a") as fname:
             for data_key, data_value in data_dict.items():
-                if data_key in group_dict and "/" + group_dict[data_key] not in fname:
-                    fname.create_dataset(
-                        name="/" + group_dict[data_key],
-                        data=np.void(cloudpickle.dumps(data_value)),
-                    )
+                if data_key in group_dict:
+                    with contextlib.suppress(ValueError):
+                        fname.create_dataset(
+                            name="/" + group_dict[data_key],
+                            data=np.void(cloudpickle.dumps(data_value)),
+                        )
 
 
 def load(file_name: str) -> dict:

--- a/src/executorlib/standalone/hdf.py
+++ b/src/executorlib/standalone/hdf.py
@@ -33,10 +33,9 @@ def dump(file_name: Optional[str], data_dict: dict) -> None:
         os.makedirs(os.path.dirname(file_name_abs), exist_ok=True)
         with h5py.File(file_name_abs, "a") as fname:
             for data_key, data_value in data_dict.items():
-                path = "/" + group_dict[data_key]
-                if data_key in group_dict and path not in fname:
+                if data_key in group_dict and "/" + group_dict[data_key] not in fname:
                     fname.create_dataset(
-                        name=path,
+                        name="/" + group_dict[data_key],
                         data=np.void(cloudpickle.dumps(data_value)),
                     )
 

--- a/src/executorlib/task_scheduler/file/shared.py
+++ b/src/executorlib/task_scheduler/file/shared.py
@@ -238,6 +238,15 @@ def _check_task_output(
 def _update_future(
     future_obj: Future, exec_flag: bool, no_error_flag: bool, result: Any
 ) -> None:
+    """
+    Update the future object with the result of the task execution.
+
+    Args:
+        future_obj (Future): The future object to be updated.
+        exec_flag (bool): Flag indicating whether the task has been executed.
+        no_error_flag (bool): Flag indicating whether the task execution resulted in an error.
+        result (Any): The result of the task execution.
+    """
     if exec_flag and no_error_flag:
         future_obj.set_result(result)
     elif exec_flag:

--- a/src/executorlib/task_scheduler/file/shared.py
+++ b/src/executorlib/task_scheduler/file/shared.py
@@ -196,7 +196,7 @@ def execute_tasks_h5(
 
 
 def _check_task_output(
-    task_key: str, future_obj: Future, cache_directory: str, duplicate_dict: dict
+    task_key: str, future_obj: Future, cache_directory: str, duplicate_dict: Optional[dict] = None
 ) -> Future:
     """
     Check the output of a task and set the result of the future object if available.
@@ -218,7 +218,7 @@ def _check_task_output(
         future_obj.set_result(result)
     elif exec_flag:
         future_obj.set_exception(result)
-    if task_key in duplicate_dict:
+    if duplicate_dict is not None and task_key in duplicate_dict:
         for duplicate_future in duplicate_dict[task_key]:
             if exec_flag and no_error_flag:
                 duplicate_future.set_result(result)
@@ -295,7 +295,7 @@ def _refresh_memory_dict(
     memory_dict: dict,
     cache_dir_dict: dict,
     process_dict: dict,
-    duplicate_dict: dict,
+    duplicate_dict: Optional[dict] = None,
     terminate_function: Optional[Callable] = None,
     pysqa_config_directory: Optional[str] = None,
     backend: Optional[str] = None,
@@ -412,12 +412,12 @@ def _cancel_futures(future_dict: dict):
 
 
 def _shutdown_executor(
-    wait: bool,
-    cancel_futures: bool,
-    memory_dict: dict,
-    process_dict: dict,
-    duplicate_dict: dict,
-    cache_dir_dict: dict,
+    wait: bool = True,
+    cancel_futures: bool = False,
+    memory_dict: Optional[dict] = None,
+    process_dict: Optional[dict] = None,
+    cache_dir_dict: Optional[dict] = None,
+    duplicate_dict: Optional[dict] = None,
     terminate_function: Optional[Callable] = None,
     pysqa_config_directory: Optional[str] = None,
     backend: Optional[str] = None,

--- a/src/executorlib/task_scheduler/file/shared.py
+++ b/src/executorlib/task_scheduler/file/shared.py
@@ -217,18 +217,32 @@ def _check_task_output(
     if not os.path.exists(file_name):
         return future_obj
     exec_flag, no_error_flag, result = get_output(file_name=file_name)
-    _update_future(future_obj=future_obj, exec_flag=exec_flag, no_error_flag=no_error_flag, result=result)
+    _update_future(
+        future_obj=future_obj,
+        exec_flag=exec_flag,
+        no_error_flag=no_error_flag,
+        result=result,
+    )
     if duplicate_dict is not None and task_key in duplicate_dict:
         for duplicate_future in duplicate_dict[task_key]:
-            _update_future(future_obj=duplicate_future, exec_flag=exec_flag, no_error_flag=no_error_flag, result=result)
+            _update_future(
+                future_obj=duplicate_future,
+                exec_flag=exec_flag,
+                no_error_flag=no_error_flag,
+                result=result,
+            )
         del duplicate_dict[task_key]
     return future_obj
 
-def _update_future(future_obj: Future, exec_flag: bool, no_error_flag: bool, result: Any) -> None:
+
+def _update_future(
+    future_obj: Future, exec_flag: bool, no_error_flag: bool, result: Any
+) -> None:
     if exec_flag and no_error_flag:
         future_obj.set_result(result)
     elif exec_flag:
         future_obj.set_exception(result)
+
 
 def _convert_args_and_kwargs(
     task_dict: dict, memory_dict: dict, file_name_dict: dict

--- a/src/executorlib/task_scheduler/file/shared.py
+++ b/src/executorlib/task_scheduler/file/shared.py
@@ -415,11 +415,11 @@ def _cancel_futures(future_dict: dict):
 
 
 def _shutdown_executor(
-    wait: bool = True,
-    cancel_futures: bool = False,
-    memory_dict: Optional[dict] = None,
-    process_dict: Optional[dict] = None,
-    cache_dir_dict: Optional[dict] = None,
+    wait: bool,
+    cancel_futures: bool,
+    memory_dict: dict,
+    process_dict: dict,
+    cache_dir_dict: dict,
     duplicate_dict: Optional[dict] = None,
     terminate_function: Optional[Callable] = None,
     pysqa_config_directory: Optional[str] = None,

--- a/src/executorlib/task_scheduler/file/shared.py
+++ b/src/executorlib/task_scheduler/file/shared.py
@@ -196,7 +196,10 @@ def execute_tasks_h5(
 
 
 def _check_task_output(
-    task_key: str, future_obj: Future, cache_directory: str, duplicate_dict: Optional[dict] = None
+    task_key: str,
+    future_obj: Future,
+    cache_directory: str,
+    duplicate_dict: Optional[dict] = None,
 ) -> Future:
     """
     Check the output of a task and set the result of the future object if available.

--- a/src/executorlib/task_scheduler/file/shared.py
+++ b/src/executorlib/task_scheduler/file/shared.py
@@ -91,6 +91,7 @@ def execute_tasks_h5(
     process_dict: dict = {}
     cache_dir_dict: dict = {}
     file_name_dict: dict = {}
+    duplicate_dict: dict = {}
     while True:
         task_dict = None
         with contextlib.suppress(queue.Empty):
@@ -101,6 +102,7 @@ def execute_tasks_h5(
                 cancel_futures=task_dict.get("cancel_futures", False),
                 memory_dict=memory_dict,
                 process_dict=process_dict,
+                duplicate_dict=duplicate_dict,
                 cache_dir_dict=cache_dir_dict,
                 terminate_function=terminate_function,
                 pysqa_config_directory=pysqa_config_directory,
@@ -175,12 +177,17 @@ def execute_tasks_h5(
                     process_dict[task_key] = queue_id
                 memory_dict[task_key] = task_dict["future"]
                 cache_dir_dict[task_key] = cache_directory
+            elif memory_dict[task_key] != task_dict["future"]:
+                if task_key not in duplicate_dict:
+                    duplicate_dict[task_key] = []
+                duplicate_dict[task_key].append(task_dict["future"])
             future_queue.task_done()
         else:
             memory_dict = _refresh_memory_dict(
                 memory_dict=memory_dict,
                 cache_dir_dict=cache_dir_dict,
                 process_dict=process_dict,
+                duplicate_dict=duplicate_dict,
                 terminate_function=terminate_function,
                 pysqa_config_directory=pysqa_config_directory,
                 backend=backend,
@@ -189,7 +196,7 @@ def execute_tasks_h5(
 
 
 def _check_task_output(
-    task_key: str, future_obj: Future, cache_directory: str
+    task_key: str, future_obj: Future, cache_directory: str, duplicate_dict: dict
 ) -> Future:
     """
     Check the output of a task and set the result of the future object if available.
@@ -198,7 +205,7 @@ def _check_task_output(
         task_key (str): The key of the task.
         future_obj (Future): The future object associated with the task.
         cache_directory (str): The directory where the HDF5 files are stored.
-
+        duplicate_dict (dict): The dictionary mapping task keys to their associated duplicate future objects.
     Returns:
         Future: The updated future object.
 
@@ -211,6 +218,13 @@ def _check_task_output(
         future_obj.set_result(result)
     elif exec_flag:
         future_obj.set_exception(result)
+    if task_key in duplicate_dict:
+        for duplicate_future in duplicate_dict[task_key]:
+            if exec_flag and no_error_flag:
+                duplicate_future.set_result(result)
+            elif exec_flag:
+                duplicate_future.set_exception(result)
+        del duplicate_dict[task_key]
     return future_obj
 
 
@@ -281,6 +295,7 @@ def _refresh_memory_dict(
     memory_dict: dict,
     cache_dir_dict: dict,
     process_dict: dict,
+    duplicate_dict: dict,
     terminate_function: Optional[Callable] = None,
     pysqa_config_directory: Optional[str] = None,
     backend: Optional[str] = None,
@@ -293,6 +308,7 @@ def _refresh_memory_dict(
         memory_dict (dict): dictionary with task keys and future objects
         cache_dir_dict (dict): dictionary with task keys and cache directories
         process_dict (dict): dictionary with task keys and process reference.
+        duplicate_dict (dict): dictionary with task keys and duplicate future objects.
         terminate_function (callable): The function to terminate the tasks.
         pysqa_config_directory (str): path to the pysqa config directory (only for pysqa based backend).
         backend (str): name of the backend used to spawn tasks.
@@ -315,6 +331,7 @@ def _refresh_memory_dict(
             task_key=key,
             future_obj=value,
             cache_directory=cache_dir_dict[key],
+            duplicate_dict=duplicate_dict,
         )
         for key, value in memory_dict.items()
         if not value.done()
@@ -399,6 +416,7 @@ def _shutdown_executor(
     cancel_futures: bool,
     memory_dict: dict,
     process_dict: dict,
+    duplicate_dict: dict,
     cache_dir_dict: dict,
     terminate_function: Optional[Callable] = None,
     pysqa_config_directory: Optional[str] = None,
@@ -421,6 +439,7 @@ def _shutdown_executor(
         cancel_futures (bool): Whether to cancel futures that have not yet started.
         memory_dict (dict): Mapping of task keys to their Future objects.
         process_dict (dict): Mapping of task keys to process handles or queue IDs.
+        duplicate_dict (dict): Mapping of task keys to lists of duplicate Future objects.
         cache_dir_dict (dict): Mapping of task keys to the cache directory for each task.
         terminate_function (Callable, optional): Function used to terminate running processes.
         pysqa_config_directory (str, optional): Path to the pysqa config directory.
@@ -433,6 +452,7 @@ def _shutdown_executor(
                 memory_dict=memory_dict,
                 cache_dir_dict=cache_dir_dict,
                 process_dict=process_dict,
+                duplicate_dict=duplicate_dict,
                 terminate_function=terminate_function,
                 pysqa_config_directory=pysqa_config_directory,
                 backend=backend,
@@ -447,6 +467,7 @@ def _shutdown_executor(
                 memory_dict=memory_dict,
                 cache_dir_dict=cache_dir_dict,
                 process_dict=process_dict,
+                duplicate_dict=duplicate_dict,
                 terminate_function=terminate_function,
                 pysqa_config_directory=pysqa_config_directory,
                 backend=backend,
@@ -465,6 +486,7 @@ def _shutdown_executor(
             memory_dict=memory_dict,
             cache_dir_dict=cache_dir_dict,
             process_dict=process_dict,
+            duplicate_dict=duplicate_dict,
             terminate_function=terminate_function,
             pysqa_config_directory=pysqa_config_directory,
             backend=backend,

--- a/src/executorlib/task_scheduler/file/shared.py
+++ b/src/executorlib/task_scheduler/file/shared.py
@@ -217,19 +217,18 @@ def _check_task_output(
     if not os.path.exists(file_name):
         return future_obj
     exec_flag, no_error_flag, result = get_output(file_name=file_name)
+    _update_future(future_obj=future_obj, exec_flag=exec_flag, no_error_flag=no_error_flag, result=result)
+    if duplicate_dict is not None and task_key in duplicate_dict:
+        for duplicate_future in duplicate_dict[task_key]:
+            _update_future(future_obj=duplicate_future, exec_flag=exec_flag, no_error_flag=no_error_flag, result=result)
+        del duplicate_dict[task_key]
+    return future_obj
+
+def _update_future(future_obj: Future, exec_flag: bool, no_error_flag: bool, result: Any) -> None:
     if exec_flag and no_error_flag:
         future_obj.set_result(result)
     elif exec_flag:
         future_obj.set_exception(result)
-    if duplicate_dict is not None and task_key in duplicate_dict:
-        for duplicate_future in duplicate_dict[task_key]:
-            if exec_flag and no_error_flag:
-                duplicate_future.set_result(result)
-            elif exec_flag:
-                duplicate_future.set_exception(result)
-        del duplicate_dict[task_key]
-    return future_obj
-
 
 def _convert_args_and_kwargs(
     task_dict: dict, memory_dict: dict, file_name_dict: dict

--- a/tests/unit/executor/test_api.py
+++ b/tests/unit/executor/test_api.py
@@ -213,7 +213,7 @@ class TestTestClusterExecutor(unittest.TestCase):
             cancel_futures=True,
             memory_dict=memory_dict,
             process_dict={},
-            duplicate_dict={},
+            duplicate_dict=None,
             cache_dir_dict={"a": "cache_dir"},
             terminate_function=None,
             pysqa_config_directory=None,

--- a/tests/unit/executor/test_api.py
+++ b/tests/unit/executor/test_api.py
@@ -156,6 +156,17 @@ class TestTestClusterExecutor(unittest.TestCase):
             self.assertEqual(len(nodes), 4)
             self.assertEqual(len(edges), 4)
 
+    def test_duplicate_futures(self):
+        with TestClusterExecutor(cache_directory="cache_dir") as exe:
+            cloudpickle_register(ind=1)
+            future_1 = exe.submit(add_with_sleep, 1, parameter_2=2)
+            future_2 = exe.submit(add_with_sleep, 1, parameter_2=2)
+            self.assertFalse(future_1.done())
+            self.assertFalse(future_2.done())
+            self.assertEqual(future_1.result(), 3)
+            self.assertEqual(future_2.result(), 3)
+            self.assertEqual(len(os.listdir("cache_dir")), 1)
+
     def test_shutdown_wait_false_cancel_futures_false(self):
         exe = TestClusterExecutor(cache_directory="shutdown_1_dir")
         cloudpickle_register(ind=1)

--- a/tests/unit/executor/test_api.py
+++ b/tests/unit/executor/test_api.py
@@ -213,6 +213,7 @@ class TestTestClusterExecutor(unittest.TestCase):
             cancel_futures=True,
             memory_dict=memory_dict,
             process_dict={},
+            duplicate_dict={},
             cache_dir_dict={"a": "cache_dir"},
             terminate_function=None,
             pysqa_config_directory=None,

--- a/tests/unit/executor/test_single_cache.py
+++ b/tests/unit/executor/test_single_cache.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 import unittest
+from time import sleep
 
 from executorlib import SingleNodeExecutor, get_cache_data
 from executorlib.standalone.serialize import cloudpickle_register
@@ -15,6 +16,11 @@ except ImportError:
 
 def get_error(a):
     raise ValueError(a)
+
+
+def sum_with_wait(a, b):
+    sleep((a + b) / 10)
+    return a + b
 
 
 class AddClass:
@@ -69,6 +75,13 @@ class TestCacheFunctions(unittest.TestCase):
             sum([sum(c["input_args"][0]) for c in cache_lst]), sum(result_lst)
         )
 
+    def test_cache_duplicate_function(self):
+        cache_directory = os.path.abspath("cache_duplicate")
+        with SingleNodeExecutor(hostname_localhost=True, cache_directory=cache_directory) as exe:
+            f1 = exe.submit(sum_with_wait, 1, 1)
+            f2 = exe.submit(sum_with_wait, 1, 1)
+            self.assertEqual(f1.result(), f2.result())
+
     def test_cache_error(self):
         cache_directory = os.path.abspath("cache_error")
         with SingleNodeExecutor(cache_directory=cache_directory) as exe:
@@ -93,3 +106,4 @@ class TestCacheFunctions(unittest.TestCase):
     def tearDown(self):
         shutil.rmtree("executorlib_cache", ignore_errors=True)
         shutil.rmtree("cache_error", ignore_errors=True)
+        shutil.rmtree("cache_duplicate", ignore_errors=True)

--- a/tests/unit/task_scheduler/file/test_backend.py
+++ b/tests/unit/task_scheduler/file/test_backend.py
@@ -50,7 +50,7 @@ class TestSharedFunctions(unittest.TestCase):
         backend_execute_task_in_file(file_name=file_name)
         future_obj = Future()
         _check_task_output(
-            task_key=task_key, future_obj=future_obj, cache_directory=cache_directory
+            task_key=task_key, future_obj=future_obj, cache_directory=cache_directory, duplicate_dict={},
         )
         self.assertTrue(future_obj.done())
         self.assertEqual(future_obj.result(), 3)
@@ -101,7 +101,7 @@ class TestSharedFunctions(unittest.TestCase):
         backend_execute_task_in_file(file_name=file_name_1)
         f1 = Future()
         _check_task_output(
-            task_key=task_key_1, future_obj=f1, cache_directory=cache_directory
+            task_key=task_key_1, future_obj=f1, cache_directory=cache_directory, duplicate_dict={},
         )
         task_key_2, data_dict = serialize_funct(
             fn=return_list,
@@ -113,7 +113,7 @@ class TestSharedFunctions(unittest.TestCase):
         backend_execute_task_in_file(file_name=file_name_2)
         f2 = Future()
         _check_task_output(
-            task_key=task_key_2, future_obj=f2, cache_directory=cache_directory
+            task_key=task_key_2, future_obj=f2, cache_directory=cache_directory, duplicate_dict={},
         )
         fs1 = FutureSelector(future=f1, selector="a")
         fs2 = FutureSelector(future=f2, selector=1)
@@ -143,7 +143,7 @@ class TestSharedFunctions(unittest.TestCase):
         backend_execute_task_in_file(file_name=file_name)
         future_obj = Future()
         _check_task_output(
-            task_key=task_key, future_obj=future_obj, cache_directory=cache_directory
+            task_key=task_key, future_obj=future_obj, cache_directory=cache_directory, duplicate_dict={},
         )
         self.assertTrue(future_obj.done())
         self.assertEqual(future_obj.result(), 3)
@@ -170,7 +170,7 @@ class TestSharedFunctions(unittest.TestCase):
         backend_execute_task_in_file(file_name=file_name)
         future_obj = Future()
         _check_task_output(
-            task_key=task_key, future_obj=future_obj, cache_directory=cache_directory
+            task_key=task_key, future_obj=future_obj, cache_directory=cache_directory, duplicate_dict={},
         )
         self.assertTrue(future_obj.done())
         self.assertEqual(future_obj.result(), 3)
@@ -198,7 +198,7 @@ class TestSharedFunctions(unittest.TestCase):
         backend_execute_task_in_file(file_name=file_name)
         future_obj = Future()
         _check_task_output(
-            task_key=task_key, future_obj=future_obj, cache_directory=cache_directory
+            task_key=task_key, future_obj=future_obj, cache_directory=cache_directory, duplicate_dict={},
         )
         self.assertTrue(future_obj.done())
         with self.assertRaises(ValueError):

--- a/tests/unit/task_scheduler/file/test_backend.py
+++ b/tests/unit/task_scheduler/file/test_backend.py
@@ -50,7 +50,7 @@ class TestSharedFunctions(unittest.TestCase):
         backend_execute_task_in_file(file_name=file_name)
         future_obj = Future()
         _check_task_output(
-            task_key=task_key, future_obj=future_obj, cache_directory=cache_directory, duplicate_dict={},
+            task_key=task_key, future_obj=future_obj, cache_directory=cache_directory,
         )
         self.assertTrue(future_obj.done())
         self.assertEqual(future_obj.result(), 3)
@@ -101,7 +101,7 @@ class TestSharedFunctions(unittest.TestCase):
         backend_execute_task_in_file(file_name=file_name_1)
         f1 = Future()
         _check_task_output(
-            task_key=task_key_1, future_obj=f1, cache_directory=cache_directory, duplicate_dict={},
+            task_key=task_key_1, future_obj=f1, cache_directory=cache_directory,
         )
         task_key_2, data_dict = serialize_funct(
             fn=return_list,
@@ -113,7 +113,7 @@ class TestSharedFunctions(unittest.TestCase):
         backend_execute_task_in_file(file_name=file_name_2)
         f2 = Future()
         _check_task_output(
-            task_key=task_key_2, future_obj=f2, cache_directory=cache_directory, duplicate_dict={},
+            task_key=task_key_2, future_obj=f2, cache_directory=cache_directory,
         )
         fs1 = FutureSelector(future=f1, selector="a")
         fs2 = FutureSelector(future=f2, selector=1)
@@ -143,7 +143,7 @@ class TestSharedFunctions(unittest.TestCase):
         backend_execute_task_in_file(file_name=file_name)
         future_obj = Future()
         _check_task_output(
-            task_key=task_key, future_obj=future_obj, cache_directory=cache_directory, duplicate_dict={},
+            task_key=task_key, future_obj=future_obj, cache_directory=cache_directory,
         )
         self.assertTrue(future_obj.done())
         self.assertEqual(future_obj.result(), 3)
@@ -170,7 +170,7 @@ class TestSharedFunctions(unittest.TestCase):
         backend_execute_task_in_file(file_name=file_name)
         future_obj = Future()
         _check_task_output(
-            task_key=task_key, future_obj=future_obj, cache_directory=cache_directory, duplicate_dict={},
+            task_key=task_key, future_obj=future_obj, cache_directory=cache_directory,
         )
         self.assertTrue(future_obj.done())
         self.assertEqual(future_obj.result(), 3)
@@ -198,7 +198,7 @@ class TestSharedFunctions(unittest.TestCase):
         backend_execute_task_in_file(file_name=file_name)
         future_obj = Future()
         _check_task_output(
-            task_key=task_key, future_obj=future_obj, cache_directory=cache_directory, duplicate_dict={},
+            task_key=task_key, future_obj=future_obj, cache_directory=cache_directory,
         )
         self.assertTrue(future_obj.done())
         with self.assertRaises(ValueError):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Avoids HDF5 write failures from duplicate dataset creation, improving reliability when saving state.
  * Ensures duplicate task submissions share results correctly and are consistently completed/cancelled during executor shutdown.

* **Tests**
  * Added tests validating caching/duplicate-task behavior and extended cleanup for the new cache scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->