### PR TITLE
[Fix] Include *_i.h5 files in get_cache_files()

### DIFF
--- a/src/executorlib/standalone/hdf.py
+++ b/src/executorlib/standalone/hdf.py
@@ -173,7 +173,11 @@ def get_cache_files(cache_directory: str) -> list[str]:
     file_lst = []
     cache_directory_abs = os.path.abspath(cache_directory)
     for dirpath, _, filenames in os.walk(cache_directory_abs):
-        file_lst += [os.path.join(dirpath, f) for f in filenames if f.endswith("_o.h5") or f.endswith("_i.h5")]
+        file_lst += [
+            os.path.join(dirpath, f)
+            for f in filenames
+            if f.endswith("_o.h5") or f.endswith("_i.h5")
+        ]
     return file_lst
 
 

--- a/src/executorlib/standalone/hdf.py
+++ b/src/executorlib/standalone/hdf.py
@@ -173,7 +173,7 @@ def get_cache_files(cache_directory: str) -> list[str]:
     file_lst = []
     cache_directory_abs = os.path.abspath(cache_directory)
     for dirpath, _, filenames in os.walk(cache_directory_abs):
-        file_lst += [os.path.join(dirpath, f) for f in filenames if f.endswith("_o.h5")]
+        file_lst += [os.path.join(dirpath, f) for f in filenames if f.endswith("_o.h5") or f.endswith("_i.h5")]
     return file_lst
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced cache discovery to include both input and output cached artifacts, providing more complete cache file access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->