### PR TITLE
rename tests

### DIFF
--- a/tests/benchmark/test_results.py
+++ b/tests/benchmark/test_results.py
@@ -2,7 +2,7 @@ import unittest
 
 
 class TestResults(unittest.TestCase):
-    def test_result(self):
+    def test_timing_benchmarks(self):
         with open("timing.log") as f:
             content = f.readlines()
         timing_dict = {l.split()[0]: float(l.split()[1]) for l in content}

--- a/tests/unit/executor/test_api.py
+++ b/tests/unit/executor/test_api.py
@@ -110,7 +110,7 @@ class TestTestClusterExecutor(unittest.TestCase):
                 cache_key="error",
             )
 
-    def test_empty(self):
+    def test_submit_single_task_and_verify_cache(self):
         with TestClusterExecutor(cache_directory="rather_this_dir") as exe:
             cloudpickle_register(ind=1)
             future = exe.submit(foo,1)

--- a/tests/unit/executor/test_single_dependencies.py
+++ b/tests/unit/executor/test_single_dependencies.py
@@ -48,14 +48,14 @@ def raise_error(parameter):
 
 
 class TestExecutorWithDependencies(unittest.TestCase):
-    def test_executor(self):
+    def test_future_chaining_resolves_dependency(self):
         with SingleNodeExecutor(max_cores=1) as exe:
             cloudpickle_register(ind=1)
             future_1 = exe.submit(add_function, 1, parameter_2=2)
             future_2 = exe.submit(add_function, 1, parameter_2=future_1)
             self.assertEqual(future_2.result(), 4)
 
-    def test_executor_no_wait(self):
+    def test_shutdown_no_wait_still_resolves_futures(self):
         exe = SingleNodeExecutor(max_cores=1)
         cloudpickle_register(ind=1)
         future_1 = exe.submit(add_function, 1, parameter_2=2)

--- a/tests/unit/executor/test_single_mpi.py
+++ b/tests/unit/executor/test_single_mpi.py
@@ -73,7 +73,7 @@ class TestExecutorBackend(unittest.TestCase):
             self.assertEqual(fs_1.result(), [(1, 2, 0), (1, 2, 1)])
             self.assertTrue(fs_1.done())
 
-    def test_errors(self):
+    def test_invalid_constructor_arguments_raise_errors(self):
         with self.assertRaises(TypeError):
             SingleNodeExecutor(
                 max_cores=1,

--- a/tests/unit/executor/test_single_mpi.py
+++ b/tests/unit/executor/test_single_mpi.py
@@ -33,7 +33,7 @@ def mpi_funct_sleep(i):
 
 
 class TestExecutorBackend(unittest.TestCase):
-    def test_meta_executor_serial(self):
+    def test_block_allocation_serial_two_cores(self):
         with SingleNodeExecutor(max_cores=2, block_allocation=True) as exe:
             cloudpickle_register(ind=1)
             fs_1 = exe.submit(calc, 1)
@@ -43,7 +43,7 @@ class TestExecutorBackend(unittest.TestCase):
             self.assertTrue(fs_1.done())
             self.assertTrue(fs_2.done())
 
-    def test_meta_executor_single(self):
+    def test_block_allocation_serial_one_core(self):
         with SingleNodeExecutor(max_cores=1, block_allocation=True) as exe:
             cloudpickle_register(ind=1)
             fs_1 = exe.submit(calc, 1)
@@ -62,7 +62,7 @@ class TestExecutorBackend(unittest.TestCase):
     @unittest.skipIf(
         skip_mpi4py_test, "mpi4py is not installed, so the mpi4py tests are skipped."
     )
-    def test_meta_executor_parallel(self):
+    def test_block_allocation_mpi_two_cores(self):
         with SingleNodeExecutor(
             max_workers=2,
             resource_dict={"cores": 2},
@@ -88,7 +88,7 @@ class TestExecutorBackendCache(unittest.TestCase):
     @unittest.skipIf(
         skip_mpi4py_test, "mpi4py is not installed, so the mpi4py tests are skipped."
     )
-    def test_meta_executor_parallel_cache(self):
+    def test_block_allocation_mpi_two_cores_with_cache(self):
         with SingleNodeExecutor(
             max_workers=2,
             resource_dict={"cores": 2},

--- a/tests/unit/executor/test_single_noblock.py
+++ b/tests/unit/executor/test_single_noblock.py
@@ -29,7 +29,7 @@ def exit_funct():
 
 
 class TestExecutorBackend(unittest.TestCase):
-    def test_meta_executor_serial_with_dependencies(self):
+    def test_no_block_allocation_disable_dependencies(self):
         with SingleNodeExecutor(
             max_cores=2,
             block_allocation=False,
@@ -43,7 +43,7 @@ class TestExecutorBackend(unittest.TestCase):
             self.assertTrue(fs_1.done())
             self.assertTrue(fs_2.done())
 
-    def test_meta_executor_serial_without_dependencies(self):
+    def test_no_block_allocation_with_dependencies(self):
         with SingleNodeExecutor(
             max_cores=2,
             block_allocation=False,
@@ -57,7 +57,7 @@ class TestExecutorBackend(unittest.TestCase):
             self.assertTrue(fs_1.done())
             self.assertTrue(fs_2.done())
 
-    def test_meta_executor_single(self):
+    def test_no_block_allocation_single_core(self):
         with SingleNodeExecutor(
             max_cores=1,
             block_allocation=False,

--- a/tests/unit/executor/test_single_noblock.py
+++ b/tests/unit/executor/test_single_noblock.py
@@ -70,7 +70,7 @@ class TestExecutorBackend(unittest.TestCase):
             self.assertTrue(fs_1.done())
             self.assertTrue(fs_2.done())
 
-    def test_errors(self):
+    def test_invalid_constructor_arguments_raise_errors(self):
         with self.assertRaises(TypeError):
             SingleNodeExecutor(
                 max_cores=1,

--- a/tests/unit/standalone/interactive/test_communication.py
+++ b/tests/unit/standalone/interactive/test_communication.py
@@ -199,10 +199,10 @@ class TestInterface(unittest.TestCase):
 
 
 class TestZMQ(unittest.TestCase):
-    def test_interface_receive(self):
+    def test_zmq_interface_receive_message(self):
         self.assertEqual(len(interface_receive(socket=None)), 0)
 
-    def test_initialize_zmq(self):
+    def test_zmq_client_initializes_socket(self):
         message = "test"
         host = "localhost"
 

--- a/tests/unit/standalone/interactive/test_spawner.py
+++ b/tests/unit/standalone/interactive/test_spawner.py
@@ -350,7 +350,7 @@ class TestFuturePool(unittest.TestCase):
     @unittest.skipIf(
         skip_mpi4py_test, "mpi4py is not installed, so the mpi4py tests are skipped."
     )
-    def test_meta(self):
+    def test_block_allocation_task_scheduler_info(self):
         meta_data_exe_dict = {
             "cores": 2,
             "spawner": "<class 'executorlib.standalone.interactive.spawner.MpiExecSpawner'>",
@@ -379,7 +379,7 @@ class TestFuturePool(unittest.TestCase):
         with TaskSchedulerBase() as exe:
             self.assertIsNone(exe.info)
 
-    def test_meta_step(self):
+    def test_one_process_task_scheduler_info(self):
         meta_data_exe_dict = {
             "cores": 2,
             "spawner": "<class 'executorlib.standalone.interactive.spawner.MpiExecSpawner'>",

--- a/tests/unit/standalone/interactive/test_spawner.py
+++ b/tests/unit/standalone/interactive/test_spawner.py
@@ -63,8 +63,8 @@ def sleep_one(i):
     return i
 
 
-class TestPyMpiExecutorSerial(unittest.TestCase):
-    def test_pympiexecutor_two_workers(self):
+class TestBlockAllocationTaskSchedulerSerial(unittest.TestCase):
+    def test_two_workers_submit_serial_tasks(self):
         with BlockAllocationTaskScheduler(
             max_workers=2,
             executor_kwargs={},
@@ -86,7 +86,7 @@ class TestPyMpiExecutorSerial(unittest.TestCase):
         ) as exe:
             self.assertEqual(exe.max_workers, 2)
 
-    def test_pympiexecutor_one_worker(self):
+    def test_one_worker_submit_serial_tasks(self):
         with BlockAllocationTaskScheduler(
             max_workers=1,
             executor_kwargs={},
@@ -101,8 +101,8 @@ class TestPyMpiExecutorSerial(unittest.TestCase):
             self.assertTrue(fs_2.done())
 
 
-class TestPyMpiExecutorStepSerial(unittest.TestCase):
-    def test_pympiexecutor_two_workers(self):
+class TestOneProcessTaskSchedulerSerial(unittest.TestCase):
+    def test_two_workers_submit_serial_tasks(self):
         with OneProcessTaskScheduler(
             max_cores=2,
             executor_kwargs={},
@@ -124,7 +124,7 @@ class TestPyMpiExecutorStepSerial(unittest.TestCase):
         ) as exe:
             self.assertEqual(exe.max_workers, 2)
 
-    def test_pympiexecutor_one_worker(self):
+    def test_one_worker_submit_serial_tasks(self):
         with OneProcessTaskScheduler(
             max_cores=1,
             executor_kwargs={},
@@ -142,8 +142,8 @@ class TestPyMpiExecutorStepSerial(unittest.TestCase):
 @unittest.skipIf(
     skip_mpi4py_test, "mpi4py is not installed, so the mpi4py tests are skipped."
 )
-class TestPyMpiExecutorMPI(unittest.TestCase):
-    def test_pympiexecutor_one_worker_with_mpi(self):
+class TestBlockAllocationTaskSchedulerMPI(unittest.TestCase):
+    def test_block_allocation_mpi_two_cores(self):
         with BlockAllocationTaskScheduler(
             max_workers=1,
             executor_kwargs={"cores": 2},
@@ -154,7 +154,7 @@ class TestPyMpiExecutorMPI(unittest.TestCase):
             self.assertEqual(fs_1.result(), [(1, 2, 0), (1, 2, 1)])
             self.assertTrue(fs_1.done())
 
-    def test_pympiexecutor_one_worker_with_mpi_multiple_submissions(self):
+    def test_block_allocation_mpi_multiple_submissions(self):
         with BlockAllocationTaskScheduler(
             max_workers=1,
             executor_kwargs={"cores": 2},
@@ -174,7 +174,7 @@ class TestPyMpiExecutorMPI(unittest.TestCase):
             [[(1, 2, 0), (1, 2, 1)], [(2, 2, 0), (2, 2, 1)], [(3, 2, 0), (3, 2, 1)]],
         )
 
-    def test_pympiexecutor_one_worker_with_mpi_echo(self):
+    def test_block_allocation_mpi_echo_broadcast(self):
         with BlockAllocationTaskScheduler(
             max_workers=1,
             executor_kwargs={"cores": 2},
@@ -188,8 +188,8 @@ class TestPyMpiExecutorMPI(unittest.TestCase):
 @unittest.skipIf(
     skip_mpi4py_test, "mpi4py is not installed, so the mpi4py tests are skipped."
 )
-class TestPyMpiStepExecutorMPI(unittest.TestCase):
-    def test_pympiexecutor_one_worker_with_mpi(self):
+class TestOneProcessTaskSchedulerMPI(unittest.TestCase):
+    def test_one_process_mpi_two_cores(self):
         with OneProcessTaskScheduler(
             max_cores=2,
             executor_kwargs={"cores": 2},
@@ -200,7 +200,7 @@ class TestPyMpiStepExecutorMPI(unittest.TestCase):
             self.assertEqual(fs_1.result(), [(1, 2, 0), (1, 2, 1)])
             self.assertTrue(fs_1.done())
 
-    def test_pympiexecutor_one_worker_with_mpi_multiple_submissions(self):
+    def test_one_process_mpi_multiple_submissions(self):
         with OneProcessTaskScheduler(
             max_cores=2,
             executor_kwargs={"cores": 2},
@@ -220,7 +220,7 @@ class TestPyMpiStepExecutorMPI(unittest.TestCase):
             [[(1, 2, 0), (1, 2, 1)], [(2, 2, 0), (2, 2, 1)], [(3, 2, 0), (3, 2, 1)]],
         )
 
-    def test_pympiexecutor_one_worker_with_mpi_echo(self):
+    def test_one_process_mpi_echo_broadcast(self):
         with OneProcessTaskScheduler(
             max_cores=2,
             executor_kwargs={"cores": 2},
@@ -231,7 +231,7 @@ class TestPyMpiStepExecutorMPI(unittest.TestCase):
         self.assertEqual(output, [2, 2])
 
 
-class TestPyMpiExecutorInitFunction(unittest.TestCase):
+class TestBlockAllocationTaskSchedulerInitFunction(unittest.TestCase):
     def test_internal_memory(self):
         with BlockAllocationTaskScheduler(
             max_workers=1,
@@ -272,8 +272,8 @@ class TestPyMpiExecutorInitFunction(unittest.TestCase):
         q.join()
 
 
-class TestFuturePool(unittest.TestCase):
-    def test_pool_serial(self):
+class TestBlockAllocationTaskScheduler(unittest.TestCase):
+    def test_submit_tracks_future_state(self):
         with BlockAllocationTaskScheduler(
             max_workers=1,
             executor_kwargs={"cores": 1},
@@ -318,7 +318,7 @@ class TestFuturePool(unittest.TestCase):
         with self.assertRaises(CancelledError):
             fs2.result()
 
-    def test_pool_serial_map(self):
+    def test_map_returns_array_results(self):
         with BlockAllocationTaskScheduler(
             max_workers=1,
             executor_kwargs={"cores": 1},
@@ -407,7 +407,7 @@ class TestFuturePool(unittest.TestCase):
     @unittest.skipIf(
         skip_mpi4py_test, "mpi4py is not installed, so the mpi4py tests are skipped."
     )
-    def test_pool_multi_core(self):
+    def test_submit_mpi_task_tracks_future_state(self):
         with BlockAllocationTaskScheduler(
             max_workers=1,
             executor_kwargs={"cores": 2},
@@ -425,7 +425,7 @@ class TestFuturePool(unittest.TestCase):
     @unittest.skipIf(
         skip_mpi4py_test, "mpi4py is not installed, so the mpi4py tests are skipped."
     )
-    def test_pool_multi_core_map(self):
+    def test_map_mpi_tasks(self):
         with BlockAllocationTaskScheduler(
             max_workers=1,
             executor_kwargs={"cores": 2},
@@ -503,7 +503,7 @@ class TestFuturePool(unittest.TestCase):
         q.join()
 
 
-class TestFuturePoolCache(unittest.TestCase):
+class TestBlockAllocationTaskSchedulerCache(unittest.TestCase):
     def tearDown(self):
         shutil.rmtree("executorlib_cache", ignore_errors=True)
 

--- a/tests/unit/task_scheduler/file/test_serial.py
+++ b/tests/unit/task_scheduler/file/test_serial.py
@@ -35,21 +35,21 @@ def get_error(a):
     skip_h5py_test, "h5py is not installed, so the h5py tests are skipped."
 )
 class TestCacheExecutorSerial(unittest.TestCase):
-    def test_executor_mixed(self):
+    def test_submit_with_positional_and_keyword_args(self):
         with FileTaskScheduler(execute_function=execute_in_subprocess) as exe:
             fs1 = exe.submit(my_funct, 1, b=2)
             self.assertFalse(fs1.done())
             self.assertEqual(fs1.result(), 3)
             self.assertTrue(fs1.done())
 
-    def test_executor_mixed_cache_key(self):
+    def test_submit_with_custom_cache_key(self):
         with FileTaskScheduler(execute_function=execute_in_subprocess) as exe:
             fs1 = exe.submit(my_funct, 1, b=2, resource_dict={"cache_key": "a/b/c"})
             self.assertFalse(fs1.done())
             self.assertEqual(fs1.result(), 3)
             self.assertTrue(fs1.done())
 
-    def test_executor_dependence_mixed(self):
+    def test_submit_dependency_with_keyword_arg_future(self):
         with FileTaskScheduler(execute_function=execute_in_subprocess) as exe:
             fs1 = exe.submit(my_funct, 1, b=2)
             fs2 = exe.submit(my_funct, 1, b=fs1)
@@ -67,7 +67,7 @@ class TestCacheExecutorSerial(unittest.TestCase):
         with self.assertRaises(ValueError):
             create_file_executor(init_function=True, executor_kwargs={})
 
-    def test_executor_dependence_error(self):
+    def test_submit_dependency_raises_when_dependencies_disabled(self):
         with self.assertRaises(ValueError):
             with FileTaskScheduler(
                 execute_function=execute_in_subprocess, disable_dependencies=True


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Renamed and reorganized many test methods and test classes across benchmark, unit, and interactive suites for clearer, scheduler-focused naming (e.g., block-allocation vs one-process scenarios).
  * Updated test names to better describe scenarios like timing benchmarks, single-task submission, MPI vs non-MPI flows, caching, and serial vs multi-core runs.
  * No test logic or behavior was changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->