### PR TITLE
[Fix] Write spawner file to executorlib cache

### DIFF
--- a/src/executorlib/task_scheduler/interactive/spawner_pysqa.py
+++ b/src/executorlib/task_scheduler/interactive/spawner_pysqa.py
@@ -189,7 +189,7 @@ class PysqaSpawner(BaseSpawner):
         if self._cwd is not None:
             working_directory = os.path.join(self._cwd, hash)
         else:
-            working_directory = os.path.abspath(hash)
+            working_directory = os.path.join(os.path.abspath("executorlib_cache"), hash)
         set_current_directory_in_environment()
         return queue_adapter.submit_job(
             command=" ".join(self.generate_command(command_lst=command_lst)),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved working directory organization for spawned processes. Temporary working directories are now created under a dedicated `executorlib_cache` folder, providing better file organization and preventing clutter in the system root.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->