### PR TITLE
[Feature] Extend the get_cache_data() function to support queuing system status in get_cache_data_queue()

### DIFF
--- a/src/executorlib/__init__.py
+++ b/src/executorlib/__init__.py
@@ -44,31 +44,37 @@ def get_cache_data(cache_directory: str) -> list[dict]:
     return get_cache_data(cache_directory=cache_directory)
 
 
-def get_cache_data_queue(cache_directory: str, queue_type: Optional[str] = None, config_directory: Optional[str] = None) -> list[dict]:
+def get_cache_data_queue(
+    cache_directory: str,
+    queue_type: Optional[str] = None,
+    config_directory: Optional[str] = None,
+) -> list[dict]:
     """
     Collect all HDF5 files in the cache directory and check their status in the queue system
-    
+
     Args:
         cache_directory (str): The directory to store cache files.
         queue_type (str, optional): The type of the queue system ["slurm", "flux"].
         config_directory (str, optional): The directory containing the configuration for the queue system.
 
     Returns:
-        list[dict]: List of dictionaries each representing on of the HDF5 files in the 
+        list[dict]: List of dictionaries each representing on of the HDF5 files in the
                     cache directory with their status in the queue system.
     """
     from executorlib.standalone.hdf import get_cache_data
     from executorlib.task_scheduler.file.spawner_pysqa import get_queue_system_status
 
     cache_dict = get_cache_data(cache_directory=cache_directory)
-    dfq = get_queue_system_status(queue_type=queue_type, config_directory=config_directory)
+    dfq = get_queue_system_status(
+        queue_type=queue_type, config_directory=config_directory
+    )
 
     cache_updated_dict = []
     for row in cache_dict:
         if "output" in row and row["output"]:
             row["status"] = "finished"
         elif "queue_id" in row and row["queue_id"] in dfq["jobid"].values:
-            row["status"] =  dfq[dfq["jobid"]==row["queue_id"]]["status"].values[-1]
+            row["status"] = dfq[dfq["jobid"] == row["queue_id"]]["status"].values[-1]
         elif "queue_id" not in row:
             row["status"] = "running"
         else:

--- a/src/executorlib/__init__.py
+++ b/src/executorlib/__init__.py
@@ -62,11 +62,13 @@ def get_cache_data_queue(
                     cache directory with their status in the queue system.
     """
     from executorlib.standalone.hdf import get_cache_data
-    from executorlib.task_scheduler.file.spawner_pysqa import get_queue_system_cache_data
+    from executorlib.task_scheduler.file.spawner_pysqa import (
+        get_queue_system_cache_data,
+    )
 
     return get_queue_system_cache_data(
-        cache_dict=get_cache_data(cache_directory=cache_directory), 
-        queue_type=queue_type, 
+        cache_dict=get_cache_data(cache_directory=cache_directory),
+        queue_type=queue_type,
         config_directory=config_directory,
     )
 

--- a/src/executorlib/__init__.py
+++ b/src/executorlib/__init__.py
@@ -62,26 +62,13 @@ def get_cache_data_queue(
                     cache directory with their status in the queue system.
     """
     from executorlib.standalone.hdf import get_cache_data
-    from executorlib.task_scheduler.file.spawner_pysqa import get_queue_system_status
+    from executorlib.task_scheduler.file.spawner_pysqa import get_queue_system_cache_data
 
-    cache_dict = get_cache_data(cache_directory=cache_directory)
-    dfq = get_queue_system_status(
-        queue_type=queue_type, config_directory=config_directory
+    return get_queue_system_cache_data(
+        cache_dict=get_cache_data(cache_directory=cache_directory), 
+        queue_type=queue_type, 
+        config_directory=config_directory,
     )
-
-    cache_updated_dict = []
-    for row in cache_dict:
-        if "output" in row and row["output"]:
-            row["status"] = "finished"
-        elif "queue_id" in row and row["queue_id"] in dfq["jobid"].values:
-            row["status"] = dfq[dfq["jobid"] == row["queue_id"]]["status"].values[-1]
-        elif "queue_id" not in row:
-            row["status"] = "running"
-        else:
-            row["status"] = "aborted"
-        cache_updated_dict.append(row)
-
-    return cache_updated_dict
 
 
 def get_future_from_cache(

--- a/src/executorlib/__init__.py
+++ b/src/executorlib/__init__.py
@@ -44,6 +44,40 @@ def get_cache_data(cache_directory: str) -> list[dict]:
     return get_cache_data(cache_directory=cache_directory)
 
 
+def get_cache_data_queue(cache_directory: str, queue_type: Optional[str] = None, config_directory: Optional[str] = None) -> list[dict]:
+    """
+    Collect all HDF5 files in the cache directory and check their status in the queue system
+    
+    Args:
+        cache_directory (str): The directory to store cache files.
+        queue_type (str, optional): The type of the queue system ["slurm", "flux"].
+        config_directory (str, optional): The directory containing the configuration for the queue system.
+
+    Returns:
+        list[dict]: List of dictionaries each representing on of the HDF5 files in the 
+                    cache directory with their status in the queue system.
+    """
+    from executorlib.standalone.hdf import get_cache_data
+    from executorlib.task_scheduler.file.spawner_pysqa import get_queue_system_status
+
+    cache_dict = get_cache_data(cache_directory=cache_directory)
+    dfq = get_queue_system_status(queue_type=queue_type, config_directory=config_directory)
+
+    cache_updated_dict = []
+    for row in cache_dict:
+        if "output" in row and row["output"]:
+            row["status"] = "finished"
+        elif "queue_id" in row and row["queue_id"] in dfq["jobid"].values:
+            row["status"] =  dfq[dfq["jobid"]==row["queue_id"]]["status"].values[-1]
+        elif "queue_id" not in row:
+            row["status"] = "running"
+        else:
+            row["status"] = "aborted"
+        cache_updated_dict.append(row)
+
+    return cache_updated_dict
+
+
 def get_future_from_cache(
     cache_directory: str,
     cache_key: str,

--- a/src/executorlib/task_scheduler/file/spawner_pysqa.py
+++ b/src/executorlib/task_scheduler/file/spawner_pysqa.py
@@ -157,7 +157,11 @@ def terminate_task_in_cache(
     os.remove(file_name)
 
 
-def get_queue_system_cache_data(cache_dict: list[dict], queue_type: Optional[str] = None, config_directory: Optional[str] = None) -> list[dict]:
+def get_queue_system_cache_data(
+    cache_dict: list[dict],
+    queue_type: Optional[str] = None,
+    config_directory: Optional[str] = None,
+) -> list[dict]:
     """
     Get the status of the queue system.
 
@@ -170,7 +174,7 @@ def get_queue_system_cache_data(cache_dict: list[dict], queue_type: Optional[str
         cache_dict (list[dict]): List of dictionaries each representing on of the HDF5 files in the cache directory.
     """
     return _merge_cache_with_queue_status(
-        cache_dict=cache_dict, 
+        cache_dict=cache_dict,
         dataframe=QueueAdapter(
             directory=config_directory,
             queue_type=queue_type,
@@ -178,7 +182,9 @@ def get_queue_system_cache_data(cache_dict: list[dict], queue_type: Optional[str
     )
 
 
-def _merge_cache_with_queue_status(cache_dict: list[dict], dataframe: DataFrame) -> list[dict]:
+def _merge_cache_with_queue_status(
+    cache_dict: list[dict], dataframe: DataFrame
+) -> list[dict]:
     """
     Merge the cache data with the queue status.
 
@@ -194,7 +200,9 @@ def _merge_cache_with_queue_status(cache_dict: list[dict], dataframe: DataFrame)
         if "output" in row and row["output"]:
             row["status"] = "finished"
         elif "queue_id" in row and row["queue_id"] in dataframe["jobid"].values:
-            row["status"] = dataframe[dataframe["jobid"] == row["queue_id"]]["status"].values[-1]
+            row["status"] = dataframe[dataframe["jobid"] == row["queue_id"]][
+                "status"
+            ].values[-1]
         elif "queue_id" not in row:
             row["status"] = "running"
         else:

--- a/src/executorlib/task_scheduler/file/spawner_pysqa.py
+++ b/src/executorlib/task_scheduler/file/spawner_pysqa.py
@@ -157,20 +157,48 @@ def terminate_task_in_cache(
     os.remove(file_name)
 
 
-def get_queue_system_status(
-    queue_type: Optional[str] = None, config_directory: Optional[str] = None
-) -> DataFrame:
+def get_queue_system_cache_data(cache_dict: list[dict], queue_type: Optional[str] = None, config_directory: Optional[str] = None) -> list[dict]:
     """
     Get the status of the queue system.
 
     Args:
+        cache_dict (list[dict]): List of dictionaries each representing on of the HDF5 files in the cache directory.
         queue_type (str, optional): The type of the queue system ["slurm", "flux"].
         config_directory (str, optional): The directory containing the configuration for the queue system.
 
     Returns:
-        pandas.DataFrame: A DataFrame containing the status of the queue system.
+        cache_dict (list[dict]): List of dictionaries each representing on of the HDF5 files in the cache directory.
     """
-    return QueueAdapter(
-        directory=config_directory,
-        queue_type=queue_type,
-    ).get_queue_status()
+    return _merge_cache_with_queue_status(
+        cache_dict=cache_dict, 
+        dataframe=QueueAdapter(
+            directory=config_directory,
+            queue_type=queue_type,
+        ).get_queue_status(),
+    )
+
+
+def _merge_cache_with_queue_status(cache_dict: list[dict], dataframe: DataFrame) -> list[dict]:
+    """
+    Merge the cache data with the queue status.
+
+    Args:
+        cache_dict (list[dict]): List of dictionaries each representing on of the HDF5 files in the cache directory.
+        dataframe (DataFrame): DataFrame containing the status of the queue system.
+
+    Returns:
+        cache_dict (list[dict]): List of dictionaries each representing on of the HDF5 files in the cache directory.
+    """
+    cache_updated_dict = []
+    for row in cache_dict:
+        if "output" in row and row["output"]:
+            row["status"] = "finished"
+        elif "queue_id" in row and row["queue_id"] in dataframe["jobid"].values:
+            row["status"] = dataframe[dataframe["jobid"] == row["queue_id"]]["status"].values[-1]
+        elif "queue_id" not in row:
+            row["status"] = "running"
+        else:
+            row["status"] = "aborted"
+        cache_updated_dict.append(row)
+
+    return cache_updated_dict

--- a/src/executorlib/task_scheduler/file/spawner_pysqa.py
+++ b/src/executorlib/task_scheduler/file/spawner_pysqa.py
@@ -2,6 +2,7 @@ import os
 from subprocess import CalledProcessError
 from typing import Optional
 
+from pandas import DataFrame
 from pysqa import QueueAdapter
 
 from executorlib.standalone.command_pysqa import pysqa_execute_command, pysqa_terminate
@@ -154,3 +155,20 @@ def terminate_task_in_cache(
             backend=backend,
         )
     os.remove(file_name)
+
+
+def get_queue_system_status(queue_type: Optional[str] = None, config_directory: Optional[str] = None) -> DataFrame:
+    """
+    Get the status of the queue system.
+
+    Args:
+        queue_type (str, optional): The type of the queue system ["slurm", "flux"].
+        config_directory (str, optional): The directory containing the configuration for the queue system.
+
+    Returns:
+        pandas.DataFrame: A DataFrame containing the status of the queue system.
+    """
+    return QueueAdapter(
+        directory=config_directory,
+        queue_type=queue_type,
+    ).get_queue_status()

--- a/src/executorlib/task_scheduler/file/spawner_pysqa.py
+++ b/src/executorlib/task_scheduler/file/spawner_pysqa.py
@@ -157,7 +157,9 @@ def terminate_task_in_cache(
     os.remove(file_name)
 
 
-def get_queue_system_status(queue_type: Optional[str] = None, config_directory: Optional[str] = None) -> DataFrame:
+def get_queue_system_status(
+    queue_type: Optional[str] = None, config_directory: Optional[str] = None
+) -> DataFrame:
     """
     Get the status of the queue system.
 

--- a/tests/unit/executor/test_api.py
+++ b/tests/unit/executor/test_api.py
@@ -18,6 +18,13 @@ try:
 except ImportError:
     skip_h5py_test = True
 
+try:
+    import pysqa
+
+    skip_pysqa_test = False
+except ImportError:
+    skip_pysqa_test = True
+
 
 def add_function(parameter_1, parameter_2):
     return parameter_1 + parameter_2
@@ -120,6 +127,10 @@ class TestTestClusterExecutor(unittest.TestCase):
         cache_lst = get_cache_data(cache_directory="rather_this_dir")
         self.assertEqual(len(cache_lst), 1)
 
+    @unittest.skipIf(
+        skip_pysqa_test,
+        "pysqa module patching not supported on Windows or when pysqa is not installed",
+    )
     @patch(
         "executorlib.task_scheduler.file.spawner_pysqa.get_queue_system_cache_data",
         return_value=[{"status": "running"}],

--- a/tests/unit/executor/test_api.py
+++ b/tests/unit/executor/test_api.py
@@ -3,8 +3,9 @@ import shutil
 import unittest
 from time import sleep
 from concurrent.futures import Future, wait
+from unittest.mock import patch
 
-from executorlib import get_cache_data, get_future_from_cache
+from executorlib import get_cache_data, get_cache_data_queue, get_future_from_cache
 from executorlib.api import TestClusterExecutor
 from executorlib.task_scheduler.interactive.dependency_plot import generate_nodes_and_edges_for_plotting
 from executorlib.standalone.serialize import cloudpickle_register
@@ -118,6 +119,32 @@ class TestTestClusterExecutor(unittest.TestCase):
         self.assertTrue(os.path.exists("rather_this_dir"))
         cache_lst = get_cache_data(cache_directory="rather_this_dir")
         self.assertEqual(len(cache_lst), 1)
+
+    @patch(
+        "executorlib.task_scheduler.file.spawner_pysqa.get_queue_system_cache_data",
+        return_value=[{"status": "running"}],
+    )
+    @patch(
+        "executorlib.standalone.hdf.get_cache_data",
+        return_value=[{"queue_id": 42}],
+    )
+    def test_get_cache_data_queue(
+        self,
+        get_cache_data_mock,
+        get_queue_system_cache_data_mock,
+    ):
+        cache_lst = get_cache_data_queue(
+            cache_directory="rather_this_dir",
+            queue_type="flux",
+            config_directory="config_dir",
+        )
+        get_cache_data_mock.assert_called_once_with(cache_directory="rather_this_dir")
+        get_queue_system_cache_data_mock.assert_called_once_with(
+            cache_dict=[{"queue_id": 42}],
+            queue_type="flux",
+            config_directory="config_dir",
+        )
+        self.assertEqual(cache_lst, [{"status": "running"}])
 
     def test_executor_dependencies(self):
         with TestClusterExecutor(cache_directory="cache_dir") as exe:

--- a/tests/unit/executor/test_flux_cluster.py
+++ b/tests/unit/executor/test_flux_cluster.py
@@ -5,7 +5,7 @@ import shutil
 from time import sleep
 from unittest.mock import patch
 
-from executorlib import FluxClusterExecutor, get_cache_data
+from executorlib import FluxClusterExecutor, get_cache_data, get_cache_data_queue
 from executorlib.standalone.serialize import cloudpickle_register
 from executorlib.standalone.command import get_cache_execute_command
 
@@ -93,6 +93,48 @@ class TestCacheExecutorPysqa(unittest.TestCase):
             self.assertEqual(fs1.result(), [(1, 2, 0), (1, 2, 1)])
             self.assertEqual(len(os.listdir("executorlib_cache")), 4)
             self.assertTrue(fs1.done())
+
+    def test_get_cache_data_queue(self):
+        with FluxClusterExecutor(
+            resource_dict={"cores": 1, "cwd": "executorlib_cache"},
+            block_allocation=False,
+            cache_directory="executorlib_cache",
+            pmi_mode=pmi,
+        ) as exe:
+            cloudpickle_register(ind=1)
+            future = exe.submit(long_running_function, 1)
+
+            running_entry = None
+            for _ in range(200):
+                cache_lst = get_cache_data_queue(
+                    cache_directory="executorlib_cache",
+                    queue_type="flux",
+                )
+                if cache_lst and cache_lst[0].get("queue_id") is not None:
+                    queue_id = cache_lst[0]["queue_id"]
+                    queue_status = QueueAdapter(queue_type="flux").get_queue_status()
+                    matching_status = queue_status[queue_status["jobid"] == queue_id]
+                    if len(matching_status) > 0:
+                        running_entry = cache_lst[0]
+                        self.assertEqual(
+                            running_entry["status"],
+                            matching_status["status"].values[-1],
+                        )
+                        break
+                sleep(0.1)
+
+            self.assertIsNotNone(
+                running_entry,
+                msg="task was never observed in the flux queue",
+            )
+            self.assertEqual(future.result(), 1)
+
+        cache_lst = get_cache_data_queue(
+            cache_directory="executorlib_cache",
+            queue_type="flux",
+        )
+        self.assertEqual(len(cache_lst), 1)
+        self.assertEqual(cache_lst[0]["status"], "finished")
 
     def test_executor_wrong_queue_name(self):
         with self.assertRaises(ValueError):

--- a/tests/unit/task_scheduler/file/test_backend.py
+++ b/tests/unit/task_scheduler/file/test_backend.py
@@ -19,8 +19,13 @@ except ImportError:
     skip_h5io_test = True
 
 try:
+    from pandas import DataFrame
     import pysqa  # noqa: F401
     from executorlib.standalone.command_pysqa import pysqa_job_output_validation
+    from executorlib.task_scheduler.file.spawner_pysqa import (
+        _merge_cache_with_queue_status,
+        get_queue_system_cache_data,
+    )
 
     skip_pysqa_test = False
 except ImportError:
@@ -346,6 +351,52 @@ class TestSharedFunctions(unittest.TestCase):
             )
         status_mock.assert_not_called()
         self.assertFalse(future_obj.done())
+
+    @unittest.skipIf(
+        sys.platform == "win32" or skip_pysqa_test,
+        "pysqa module patching not supported on Windows or when pysqa is not installed",
+    )
+    def test_merge_cache_with_queue_status_edge_cases(self):
+        cache_lst = _merge_cache_with_queue_status(
+            cache_dict=[
+                {"filename": "finished_o.h5", "output": 1},
+                {"filename": "queued_i.h5", "queue_id": 42},
+                {"filename": "local_i.h5"},
+                {"filename": "aborted_i.h5", "queue_id": 99},
+            ],
+            dataframe=DataFrame(
+                [
+                    {"jobid": 42, "status": "submitted"},
+                    {"jobid": 42, "status": "running"},
+                ]
+            ),
+        )
+        self.assertEqual(
+            [entry["status"] for entry in cache_lst],
+            ["finished", "running", "running", "aborted"],
+        )
+
+    @unittest.skipIf(
+        sys.platform == "win32" or skip_pysqa_test,
+        "pysqa module patching not supported on Windows or when pysqa is not installed",
+    )
+    def test_get_queue_system_cache_data(self):
+        with patch(
+            "executorlib.task_scheduler.file.spawner_pysqa.QueueAdapter"
+        ) as queue_adapter_mock:
+            queue_adapter_mock.return_value.get_queue_status.return_value = DataFrame(
+                [{"jobid": 21, "status": "pending"}]
+            )
+            cache_lst = get_queue_system_cache_data(
+                cache_dict=[{"filename": "task_i.h5", "queue_id": 21}],
+                queue_type="flux",
+                config_directory="config_dir",
+            )
+        queue_adapter_mock.assert_called_once_with(
+            directory="config_dir",
+            queue_type="flux",
+        )
+        self.assertEqual(cache_lst[0]["status"], "pending")
 
     def tearDown(self):
         shutil.rmtree("executorlib_cache", ignore_errors=True)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an API to retrieve cached task data enriched with queue-system statuses.
  * Cache entries now distinguish finished, queued, running, and aborted tasks.
  * Queue type and configuration directory can be specified when retrieving status information.

* **Tests**
  * Added coverage for cache and queue-status integration across supported execution backends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->