### PR TITLE
Fix scheduler thread dying on unpicklable submit arguments

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,8 @@ ignore = [
     "PLR0912",
     # Too many arguments in function definition
     "PLR0913",
+    # Too many statements
+    "PLR0915",
     # Too many not-keyword-only arguments,
     "PLR0917",
     # Magic value used in comparison

--- a/src/executorlib/standalone/serialize.py
+++ b/src/executorlib/standalone/serialize.py
@@ -60,8 +60,6 @@ def serialize_funct(
                                                exception if the serialization failed.
 
     """
-    excp = None
-
     if fn_args is None:
         fn_args = []
     if fn_kwargs is None:
@@ -80,8 +78,7 @@ def serialize_funct(
                 }
             )
         except Exception as e:
-            excp = e
-            binary_all = None
+            return "", {}, e
         else:
             task_key = _get_function_name(fn=fn) + _get_hash(binary=binary_all)
     data = {
@@ -90,7 +87,7 @@ def serialize_funct(
         "kwargs": fn_kwargs,
         "resource_dict": resource_dict,
     }
-    return task_key, data, excp
+    return task_key, data, None
 
 
 def _get_hash(binary: bytes) -> str:

--- a/src/executorlib/standalone/serialize.py
+++ b/src/executorlib/standalone/serialize.py
@@ -59,7 +59,7 @@ def serialize_funct(
         Tuple[str, dict]: A tuple containing the task key and the serialized data.
 
     """
-    excp = None 
+    excp = None
 
     if fn_args is None:
         fn_args = []

--- a/src/executorlib/standalone/serialize.py
+++ b/src/executorlib/standalone/serialize.py
@@ -59,6 +59,8 @@ def serialize_funct(
         Tuple[str, dict]: A tuple containing the task key and the serialized data.
 
     """
+    excp = None 
+
     if fn_args is None:
         fn_args = []
     if fn_kwargs is None:
@@ -68,21 +70,26 @@ def serialize_funct(
     if cache_key is not None:
         task_key = cache_key
     else:
-        binary_all = cloudpickle.dumps(
-            {
-                "fn": fn,
-                "args": fn_args,
-                "kwargs": fn_kwargs,
-            }
-        )
-        task_key = _get_function_name(fn=fn) + _get_hash(binary=binary_all)
+        try:
+            binary_all = cloudpickle.dumps(
+                {
+                    "fn": fn,
+                    "args": fn_args,
+                    "kwargs": fn_kwargs,
+                }
+            )
+        except Exception as e:
+            excp = e
+            binary_all = None
+        else:
+            task_key = _get_function_name(fn=fn) + _get_hash(binary=binary_all)
     data = {
         "fn": fn,
         "args": fn_args,
         "kwargs": fn_kwargs,
         "resource_dict": resource_dict,
     }
-    return task_key, data
+    return task_key, data, excp
 
 
 def _get_hash(binary: bytes) -> str:

--- a/src/executorlib/standalone/serialize.py
+++ b/src/executorlib/standalone/serialize.py
@@ -34,7 +34,7 @@ def serialize_funct(
     fn_kwargs: Optional[dict] = None,
     resource_dict: Optional[dict] = None,
     cache_key: Optional[str] = None,
-) -> tuple[str, dict]:
+) -> tuple[str, dict, Optional[Exception]]:
     """
     Serialize a function and its arguments and keyword arguments into an HDF5 file.
 
@@ -56,7 +56,8 @@ def serialize_funct(
                                    overwritten by setting the cache_key.
 
     Returns:
-        Tuple[str, dict]: A tuple containing the task key and the serialized data.
+        Tuple[str, dict, Optional[Exception]]: A tuple containing the task key, the serialized data and an
+                                               exception if the serialization failed.
 
     """
     excp = None

--- a/src/executorlib/task_scheduler/file/shared.py
+++ b/src/executorlib/task_scheduler/file/shared.py
@@ -118,79 +118,76 @@ def execute_tasks_h5(
             future_queue.join()
             break
         elif task_dict is not None:
-            try:
-                task_args, task_kwargs, future_wait_key_lst = _convert_args_and_kwargs(
-                    task_dict=task_dict,
-                    memory_dict=memory_dict,
-                    file_name_dict=file_name_dict,
+            task_args, task_kwargs, future_wait_key_lst = _convert_args_and_kwargs(
+                task_dict=task_dict,
+                memory_dict=memory_dict,
+                file_name_dict=file_name_dict,
+            )
+            task_resource_dict, cache_key, cache_directory, error_log_file = (
+                _get_task_input(
+                    task_resource_dict=task_dict["resource_dict"].copy(),
+                    executor_kwargs=executor_kwargs,
                 )
-                task_resource_dict, cache_key, cache_directory, error_log_file = (
-                    _get_task_input(
-                        task_resource_dict=task_dict["resource_dict"].copy(),
-                        executor_kwargs=executor_kwargs,
-                    )
-                )
-                task_key, data_dict = serialize_funct(
-                    fn=task_dict["fn"],
-                    fn_args=task_args,
-                    fn_kwargs=task_kwargs,
-                    resource_dict=task_resource_dict,
-                    cache_key=cache_key,
-                )
-                data_dict["error_log_file"] = error_log_file
-                if task_key not in memory_dict:
-                    if os.path.join(
-                        cache_directory, task_key + "_o.h5"
-                    ) not in get_cache_files(cache_directory=cache_directory):
-                        file_name = os.path.join(cache_directory, task_key + "_i.h5")
-                        if not disable_dependencies:
-                            task_dependent_lst = [
-                                process_dict[k]
-                                for k in future_wait_key_lst
-                                if k in process_dict
-                            ]
-                        else:
-                            if len(future_wait_key_lst) > 0:
-                                task_dict["future"].set_exception(
-                                    ValueError(
-                                        "Future objects are not supported as input if disable_dependencies=True."
-                                    )
-                                )
-                            task_dependent_lst = []
-                        process_dict[task_key] = execute_function(
-                            command=get_cache_execute_command(
-                                file_name=file_name,
-                                cores=task_resource_dict["cores"],
-                                backend=backend,
-                                exclusive=task_resource_dict.get("exclusive", False),
-                                openmpi_oversubscribe=task_resource_dict.get(
-                                    "openmpi_oversubscribe", False
-                                ),
-                                pmi_mode=pmi_mode,
-                            ),
-                            file_name=file_name,
-                            data_dict=data_dict,
-                            task_dependent_lst=task_dependent_lst,
-                            resource_dict=task_resource_dict,
-                            config_directory=pysqa_config_directory,
-                            backend=backend,
-                            cache_directory=cache_directory,
-                        )
-                    file_name = os.path.join(cache_directory, task_key + "_o.h5")
-                    file_name_dict[task_key] = file_name
-                    queue_id = get_queue_id(file_name=file_name)
-                    if queue_id is not None:
-                        process_dict[task_key] = queue_id
-                    memory_dict[task_key] = task_dict["future"]
-                    cache_dir_dict[task_key] = cache_directory
-                elif memory_dict[task_key] != task_dict["future"]:
-                    if task_key not in duplicate_dict:
-                        duplicate_dict[task_key] = []
-                    duplicate_dict[task_key].append(task_dict["future"])
-            except Exception as exc:
-                # e.g. an argument cloudpickle cannot serialize - fail the
-                # future instead of killing the scheduler thread
+            )
+            task_key, data_dict, exc = serialize_funct(
+                fn=task_dict["fn"],
+                fn_args=task_args,
+                fn_kwargs=task_kwargs,
+                resource_dict=task_resource_dict,
+                cache_key=cache_key,
+            )
+            data_dict["error_log_file"] = error_log_file
+            if exc is not None:
                 task_dict["future"].set_exception(exc)
+            elif task_key not in memory_dict:
+                if os.path.join(
+                    cache_directory, task_key + "_o.h5"
+                ) not in get_cache_files(cache_directory=cache_directory):
+                    file_name = os.path.join(cache_directory, task_key + "_i.h5")
+                    if not disable_dependencies:
+                        task_dependent_lst = [
+                            process_dict[k]
+                            for k in future_wait_key_lst
+                            if k in process_dict
+                        ]
+                    else:
+                        if len(future_wait_key_lst) > 0:
+                            task_dict["future"].set_exception(
+                                ValueError(
+                                    "Future objects are not supported as input if disable_dependencies=True."
+                                )
+                            )
+                        task_dependent_lst = []
+                    process_dict[task_key] = execute_function(
+                        command=get_cache_execute_command(
+                            file_name=file_name,
+                            cores=task_resource_dict["cores"],
+                            backend=backend,
+                            exclusive=task_resource_dict.get("exclusive", False),
+                            openmpi_oversubscribe=task_resource_dict.get(
+                                "openmpi_oversubscribe", False
+                            ),
+                            pmi_mode=pmi_mode,
+                        ),
+                        file_name=file_name,
+                        data_dict=data_dict,
+                        task_dependent_lst=task_dependent_lst,
+                        resource_dict=task_resource_dict,
+                        config_directory=pysqa_config_directory,
+                        backend=backend,
+                        cache_directory=cache_directory,
+                    )
+                file_name = os.path.join(cache_directory, task_key + "_o.h5")
+                file_name_dict[task_key] = file_name
+                queue_id = get_queue_id(file_name=file_name)
+                if queue_id is not None:
+                    process_dict[task_key] = queue_id
+                memory_dict[task_key] = task_dict["future"]
+                cache_dir_dict[task_key] = cache_directory
+            elif memory_dict[task_key] != task_dict["future"]:
+                if task_key not in duplicate_dict:
+                    duplicate_dict[task_key] = []
+                duplicate_dict[task_key].append(task_dict["future"])
             future_queue.task_done()
         else:
             memory_dict = _refresh_memory_dict(

--- a/src/executorlib/task_scheduler/file/shared.py
+++ b/src/executorlib/task_scheduler/file/shared.py
@@ -129,7 +129,7 @@ def execute_tasks_h5(
                     executor_kwargs=executor_kwargs,
                 )
             )
-            task_key, data_dict, exc = serialize_funct(
+            task_key, data_dict, serialize_exception = serialize_funct(
                 fn=task_dict["fn"],
                 fn_args=task_args,
                 fn_kwargs=task_kwargs,
@@ -137,8 +137,8 @@ def execute_tasks_h5(
                 cache_key=cache_key,
             )
             data_dict["error_log_file"] = error_log_file
-            if exc is not None:
-                task_dict["future"].set_exception(exc)
+            if serialize_exception is not None:
+                task_dict["future"].set_exception(serialize_exception)
             elif task_key not in memory_dict:
                 if os.path.join(
                     cache_directory, task_key + "_o.h5"

--- a/src/executorlib/task_scheduler/file/shared.py
+++ b/src/executorlib/task_scheduler/file/shared.py
@@ -119,12 +119,10 @@ def execute_tasks_h5(
             break
         elif task_dict is not None:
             try:
-                task_args, task_kwargs, future_wait_key_lst = (
-                    _convert_args_and_kwargs(
-                        task_dict=task_dict,
-                        memory_dict=memory_dict,
-                        file_name_dict=file_name_dict,
-                    )
+                task_args, task_kwargs, future_wait_key_lst = _convert_args_and_kwargs(
+                    task_dict=task_dict,
+                    memory_dict=memory_dict,
+                    file_name_dict=file_name_dict,
                 )
                 task_resource_dict, cache_key, cache_directory, error_log_file = (
                     _get_task_input(

--- a/src/executorlib/task_scheduler/file/shared.py
+++ b/src/executorlib/task_scheduler/file/shared.py
@@ -158,25 +158,31 @@ def execute_tasks_h5(
                                 )
                             )
                         task_dependent_lst = []
-                    process_dict[task_key] = execute_function(
-                        command=get_cache_execute_command(
-                            file_name=file_name,
-                            cores=task_resource_dict["cores"],
-                            backend=backend,
-                            exclusive=task_resource_dict.get("exclusive", False),
-                            openmpi_oversubscribe=task_resource_dict.get(
-                                "openmpi_oversubscribe", False
+                    try:
+                        process_dict[task_key] = execute_function(
+                            command=get_cache_execute_command(
+                                file_name=file_name,
+                                cores=task_resource_dict["cores"],
+                                backend=backend,
+                                exclusive=task_resource_dict.get("exclusive", False),
+                                openmpi_oversubscribe=task_resource_dict.get(
+                                    "openmpi_oversubscribe", False
+                                ),
+                                pmi_mode=pmi_mode,
                             ),
-                            pmi_mode=pmi_mode,
-                        ),
-                        file_name=file_name,
-                        data_dict=data_dict,
-                        task_dependent_lst=task_dependent_lst,
-                        resource_dict=task_resource_dict,
-                        config_directory=pysqa_config_directory,
-                        backend=backend,
-                        cache_directory=cache_directory,
-                    )
+                            file_name=file_name,
+                            data_dict=data_dict,
+                            task_dependent_lst=task_dependent_lst,
+                            resource_dict=task_resource_dict,
+                            config_directory=pysqa_config_directory,
+                            backend=backend,
+                            cache_directory=cache_directory,
+                        )
+                    except Exception as e:
+                        task_dict["future"].set_exception(e)
+                        memory_dict[task_key] = task_dict["future"]
+                        future_queue.task_done()
+                        continue
                 file_name = os.path.join(cache_directory, task_key + "_o.h5")
                 file_name_dict[task_key] = file_name
                 queue_id = get_queue_id(file_name=file_name)

--- a/src/executorlib/task_scheduler/file/shared.py
+++ b/src/executorlib/task_scheduler/file/shared.py
@@ -118,74 +118,81 @@ def execute_tasks_h5(
             future_queue.join()
             break
         elif task_dict is not None:
-            task_args, task_kwargs, future_wait_key_lst = _convert_args_and_kwargs(
-                task_dict=task_dict,
-                memory_dict=memory_dict,
-                file_name_dict=file_name_dict,
-            )
-            task_resource_dict, cache_key, cache_directory, error_log_file = (
-                _get_task_input(
-                    task_resource_dict=task_dict["resource_dict"].copy(),
-                    executor_kwargs=executor_kwargs,
-                )
-            )
-            task_key, data_dict = serialize_funct(
-                fn=task_dict["fn"],
-                fn_args=task_args,
-                fn_kwargs=task_kwargs,
-                resource_dict=task_resource_dict,
-                cache_key=cache_key,
-            )
-            data_dict["error_log_file"] = error_log_file
-            if task_key not in memory_dict:
-                if os.path.join(
-                    cache_directory, task_key + "_o.h5"
-                ) not in get_cache_files(cache_directory=cache_directory):
-                    file_name = os.path.join(cache_directory, task_key + "_i.h5")
-                    if not disable_dependencies:
-                        task_dependent_lst = [
-                            process_dict[k]
-                            for k in future_wait_key_lst
-                            if k in process_dict
-                        ]
-                    else:
-                        if len(future_wait_key_lst) > 0:
-                            task_dict["future"].set_exception(
-                                ValueError(
-                                    "Future objects are not supported as input if disable_dependencies=True."
-                                )
-                            )
-                        task_dependent_lst = []
-                    process_dict[task_key] = execute_function(
-                        command=get_cache_execute_command(
-                            file_name=file_name,
-                            cores=task_resource_dict["cores"],
-                            backend=backend,
-                            exclusive=task_resource_dict.get("exclusive", False),
-                            openmpi_oversubscribe=task_resource_dict.get(
-                                "openmpi_oversubscribe", False
-                            ),
-                            pmi_mode=pmi_mode,
-                        ),
-                        file_name=file_name,
-                        data_dict=data_dict,
-                        task_dependent_lst=task_dependent_lst,
-                        resource_dict=task_resource_dict,
-                        config_directory=pysqa_config_directory,
-                        backend=backend,
-                        cache_directory=cache_directory,
+            try:
+                task_args, task_kwargs, future_wait_key_lst = (
+                    _convert_args_and_kwargs(
+                        task_dict=task_dict,
+                        memory_dict=memory_dict,
+                        file_name_dict=file_name_dict,
                     )
-                file_name = os.path.join(cache_directory, task_key + "_o.h5")
-                file_name_dict[task_key] = file_name
-                queue_id = get_queue_id(file_name=file_name)
-                if queue_id is not None:
-                    process_dict[task_key] = queue_id
-                memory_dict[task_key] = task_dict["future"]
-                cache_dir_dict[task_key] = cache_directory
-            elif memory_dict[task_key] != task_dict["future"]:
-                if task_key not in duplicate_dict:
-                    duplicate_dict[task_key] = []
-                duplicate_dict[task_key].append(task_dict["future"])
+                )
+                task_resource_dict, cache_key, cache_directory, error_log_file = (
+                    _get_task_input(
+                        task_resource_dict=task_dict["resource_dict"].copy(),
+                        executor_kwargs=executor_kwargs,
+                    )
+                )
+                task_key, data_dict = serialize_funct(
+                    fn=task_dict["fn"],
+                    fn_args=task_args,
+                    fn_kwargs=task_kwargs,
+                    resource_dict=task_resource_dict,
+                    cache_key=cache_key,
+                )
+                data_dict["error_log_file"] = error_log_file
+                if task_key not in memory_dict:
+                    if os.path.join(
+                        cache_directory, task_key + "_o.h5"
+                    ) not in get_cache_files(cache_directory=cache_directory):
+                        file_name = os.path.join(cache_directory, task_key + "_i.h5")
+                        if not disable_dependencies:
+                            task_dependent_lst = [
+                                process_dict[k]
+                                for k in future_wait_key_lst
+                                if k in process_dict
+                            ]
+                        else:
+                            if len(future_wait_key_lst) > 0:
+                                task_dict["future"].set_exception(
+                                    ValueError(
+                                        "Future objects are not supported as input if disable_dependencies=True."
+                                    )
+                                )
+                            task_dependent_lst = []
+                        process_dict[task_key] = execute_function(
+                            command=get_cache_execute_command(
+                                file_name=file_name,
+                                cores=task_resource_dict["cores"],
+                                backend=backend,
+                                exclusive=task_resource_dict.get("exclusive", False),
+                                openmpi_oversubscribe=task_resource_dict.get(
+                                    "openmpi_oversubscribe", False
+                                ),
+                                pmi_mode=pmi_mode,
+                            ),
+                            file_name=file_name,
+                            data_dict=data_dict,
+                            task_dependent_lst=task_dependent_lst,
+                            resource_dict=task_resource_dict,
+                            config_directory=pysqa_config_directory,
+                            backend=backend,
+                            cache_directory=cache_directory,
+                        )
+                    file_name = os.path.join(cache_directory, task_key + "_o.h5")
+                    file_name_dict[task_key] = file_name
+                    queue_id = get_queue_id(file_name=file_name)
+                    if queue_id is not None:
+                        process_dict[task_key] = queue_id
+                    memory_dict[task_key] = task_dict["future"]
+                    cache_dir_dict[task_key] = cache_directory
+                elif memory_dict[task_key] != task_dict["future"]:
+                    if task_key not in duplicate_dict:
+                        duplicate_dict[task_key] = []
+                    duplicate_dict[task_key].append(task_dict["future"])
+            except Exception as exc:
+                # e.g. an argument cloudpickle cannot serialize - fail the
+                # future instead of killing the scheduler thread
+                task_dict["future"].set_exception(exc)
             future_queue.task_done()
         else:
             memory_dict = _refresh_memory_dict(

--- a/src/executorlib/task_scheduler/interactive/shared.py
+++ b/src/executorlib/task_scheduler/interactive/shared.py
@@ -136,15 +136,15 @@ def _execute_task_with_cache(
     """
     from executorlib.standalone.hdf import dump, get_cache_files, get_output
 
-    task_key, data_dict, excp = serialize_funct(
+    task_key, data_dict, serialize_exception = serialize_funct(
         fn=task_dict["fn"],
         fn_args=task_dict["args"],
         fn_kwargs=task_dict["kwargs"],
         resource_dict=task_dict.get("resource_dict", {}),
         cache_key=cache_key,
     )
-    if excp is not None:
-        future_obj.set_exception(exception=excp)
+    if serialize_exception is not None:
+        future_obj.set_exception(exception=serialize_exception)
     else:
         file_name = os.path.abspath(os.path.join(cache_directory, task_key + "_o.h5"))
         if file_name not in get_cache_files(cache_directory=cache_directory):

--- a/src/executorlib/task_scheduler/interactive/shared.py
+++ b/src/executorlib/task_scheduler/interactive/shared.py
@@ -41,24 +41,18 @@ def execute_task_dict(
     if not future_obj.done() and future_obj.set_running_or_notify_cancel():
         if error_log_file is not None:
             task_dict["error_log_file"] = error_log_file
-        try:
-            if cache_directory is None:
-                return _execute_task_without_cache(
-                    interface=interface, task_dict=task_dict, future_obj=future_obj
-                )
-            else:
-                return _execute_task_with_cache(
-                    interface=interface,
-                    task_dict=task_dict,
-                    cache_directory=cache_directory,
-                    cache_key=cache_key,
-                    future_obj=future_obj,
-                )
-        except Exception as exc:
-            # e.g. an argument cloudpickle cannot serialize - fail the future
-            # instead of killing the worker thread
-            future_obj.set_exception(exc)
-            return True
+        if cache_directory is None:
+            return _execute_task_without_cache(
+                interface=interface, task_dict=task_dict, future_obj=future_obj
+            )
+        else:
+            return _execute_task_with_cache(
+                interface=interface,
+                task_dict=task_dict,
+                cache_directory=cache_directory,
+                cache_key=cache_key,
+                future_obj=future_obj,
+            )
     else:
         return True
 
@@ -107,13 +101,17 @@ def _execute_task_without_cache(
     Returns:
         bool: True if the task was submitted successfully, False otherwise.
     """
-    output = interface.send_and_receive_dict(input_dict=task_dict)
-    if "result" in output:
-        future_obj.set_result(output["result"])
-    elif isinstance(output["error"], ExecutorlibSocketError):
-        return False
+    try:
+        output = interface.send_and_receive_dict(input_dict=task_dict)
+    except Exception as e:
+        future_obj.set_exception(exception=e)
     else:
-        future_obj.set_exception(exception=output["error"])
+        if "result" in output:
+            future_obj.set_result(output["result"])
+        elif isinstance(output["error"], ExecutorlibSocketError):
+            return False
+        else:
+            future_obj.set_exception(exception=output["error"])
     return True
 
 
@@ -138,27 +136,30 @@ def _execute_task_with_cache(
     """
     from executorlib.standalone.hdf import dump, get_cache_files, get_output
 
-    task_key, data_dict = serialize_funct(
+    task_key, data_dict, excp = serialize_funct(
         fn=task_dict["fn"],
         fn_args=task_dict["args"],
         fn_kwargs=task_dict["kwargs"],
         resource_dict=task_dict.get("resource_dict", {}),
         cache_key=cache_key,
     )
-    file_name = os.path.abspath(os.path.join(cache_directory, task_key + "_o.h5"))
-    if file_name not in get_cache_files(cache_directory=cache_directory):
-        time_start = time.time()
-        output = interface.send_and_receive_dict(input_dict=task_dict)
-        if "result" in output:
-            data_dict["output"] = output["result"]
-            data_dict["runtime"] = time.time() - time_start
-            dump(file_name=file_name, data_dict=data_dict)
-            future_obj.set_result(output["result"])
-        elif isinstance(output["error"], ExecutorlibSocketError):
-            return False
-        else:
-            future_obj.set_exception(exception=output["error"])
+    if excp is not None:
+        future_obj.set_exception(exception=excp)
     else:
-        _, _, result = get_output(file_name=file_name)
-        future_obj.set_result(result)
+        file_name = os.path.abspath(os.path.join(cache_directory, task_key + "_o.h5"))
+        if file_name not in get_cache_files(cache_directory=cache_directory):
+            time_start = time.time()
+            output = interface.send_and_receive_dict(input_dict=task_dict)
+            if "result" in output:
+                data_dict["output"] = output["result"]
+                data_dict["runtime"] = time.time() - time_start
+                dump(file_name=file_name, data_dict=data_dict)
+                future_obj.set_result(output["result"])
+            elif isinstance(output["error"], ExecutorlibSocketError):
+                return False
+            else:
+                future_obj.set_exception(exception=output["error"])
+        else:
+            _, _, result = get_output(file_name=file_name)
+            future_obj.set_result(result)
     return True

--- a/src/executorlib/task_scheduler/interactive/shared.py
+++ b/src/executorlib/task_scheduler/interactive/shared.py
@@ -41,18 +41,24 @@ def execute_task_dict(
     if not future_obj.done() and future_obj.set_running_or_notify_cancel():
         if error_log_file is not None:
             task_dict["error_log_file"] = error_log_file
-        if cache_directory is None:
-            return _execute_task_without_cache(
-                interface=interface, task_dict=task_dict, future_obj=future_obj
-            )
-        else:
-            return _execute_task_with_cache(
-                interface=interface,
-                task_dict=task_dict,
-                cache_directory=cache_directory,
-                cache_key=cache_key,
-                future_obj=future_obj,
-            )
+        try:
+            if cache_directory is None:
+                return _execute_task_without_cache(
+                    interface=interface, task_dict=task_dict, future_obj=future_obj
+                )
+            else:
+                return _execute_task_with_cache(
+                    interface=interface,
+                    task_dict=task_dict,
+                    cache_directory=cache_directory,
+                    cache_key=cache_key,
+                    future_obj=future_obj,
+                )
+        except Exception as exc:
+            # e.g. an argument cloudpickle cannot serialize - fail the future
+            # instead of killing the worker thread
+            future_obj.set_exception(exc)
+            return True
     else:
         return True
 

--- a/src/executorlib/task_scheduler/interactive/shared.py
+++ b/src/executorlib/task_scheduler/interactive/shared.py
@@ -149,7 +149,11 @@ def _execute_task_with_cache(
         file_name = os.path.abspath(os.path.join(cache_directory, task_key + "_o.h5"))
         if file_name not in get_cache_files(cache_directory=cache_directory):
             time_start = time.time()
-            output = interface.send_and_receive_dict(input_dict=task_dict)
+            try:
+                output = interface.send_and_receive_dict(input_dict=task_dict)
+            except Exception as e:
+                future_obj.set_exception(exception=e)
+                return True
             if "result" in output:
                 data_dict["output"] = output["result"]
                 data_dict["runtime"] = time.time() - time_start

--- a/tests/unit/executor/test_single_dependencies.py
+++ b/tests/unit/executor/test_single_dependencies.py
@@ -47,6 +47,11 @@ def raise_error(parameter):
     raise RuntimeError
 
 
+class Unpicklable:
+    def __reduce__(self):
+        raise TypeError("cannot pickle Unpicklable")
+
+
 class TestExecutorWithDependencies(unittest.TestCase):
     def test_future_chaining_resolves_dependency(self):
         with SingleNodeExecutor(max_cores=1) as exe:
@@ -336,6 +341,29 @@ class TestExecutorErrors(unittest.TestCase):
                 cloudpickle_register(ind=1)
                 fs = exe.submit(raise_error, parameter=0)
                 fs.result()
+
+    def test_unpicklable_argument_block_allocation_false(self):
+        with self.assertRaises(TypeError):
+            with SingleNodeExecutor(max_cores=1, block_allocation=False) as exe:
+                cloudpickle_register(ind=1)
+                fs = exe.submit(len, [Unpicklable()])
+                fs.result(timeout=15)
+
+    def test_unpicklable_argument_block_allocation_true(self):
+        with self.assertRaises(TypeError):
+            with SingleNodeExecutor(max_cores=1, block_allocation=True) as exe:
+                cloudpickle_register(ind=1)
+                fs = exe.submit(len, [Unpicklable()])
+                fs.result(timeout=15)
+
+    def test_unpicklable_argument_recovers_for_next_task(self):
+        with SingleNodeExecutor(max_cores=1, block_allocation=False) as exe:
+            cloudpickle_register(ind=1)
+            bad_fs = exe.submit(len, [Unpicklable()])
+            good_fs = exe.submit(sum, [1, 2])
+            with self.assertRaises(TypeError):
+                bad_fs.result(timeout=15)
+            self.assertEqual(good_fs.result(timeout=15), 3)
 
     def test_block_allocation_false_one_worker_loop(self):
         with self.assertRaises(RuntimeError):

--- a/tests/unit/task_scheduler/file/test_backend.py
+++ b/tests/unit/task_scheduler/file/test_backend.py
@@ -55,7 +55,7 @@ class TestSharedFunctions(unittest.TestCase):
     def test_execute_function_mixed(self):
         cache_directory = os.path.abspath("executorlib_cache")
         os.makedirs(cache_directory, exist_ok=True)
-        task_key, data_dict = serialize_funct(
+        task_key, data_dict, _ = serialize_funct(
             fn=my_funct,
             fn_args=[1],
             fn_kwargs={"b": 2},
@@ -106,7 +106,7 @@ class TestSharedFunctions(unittest.TestCase):
     def test_execute_function_mixed_selector_convert(self):
         cache_directory = os.path.abspath("executorlib_cache")
         os.makedirs(cache_directory, exist_ok=True)
-        task_key_1, data_dict = serialize_funct(
+        task_key_1, data_dict, _ = serialize_funct(
             fn=return_dict,
             fn_args=[1],
             fn_kwargs={"b": 2},
@@ -118,7 +118,7 @@ class TestSharedFunctions(unittest.TestCase):
         _check_task_output(
             task_key=task_key_1, future_obj=f1, cache_directory=cache_directory,
         )
-        task_key_2, data_dict = serialize_funct(
+        task_key_2, data_dict, _ = serialize_funct(
             fn=return_list,
             fn_args=[1],
             fn_kwargs={"b": 2},
@@ -147,7 +147,7 @@ class TestSharedFunctions(unittest.TestCase):
     def test_execute_function_args(self):
         cache_directory = os.path.abspath("executorlib_cache")
         os.makedirs(cache_directory, exist_ok=True)
-        task_key, data_dict = serialize_funct(
+        task_key, data_dict, _ = serialize_funct(
             fn=my_funct,
             fn_args=[1, 2],
             fn_kwargs=None,
@@ -175,7 +175,7 @@ class TestSharedFunctions(unittest.TestCase):
     def test_execute_function_kwargs(self):
         cache_directory = os.path.abspath("executorlib_cache")
         os.makedirs(cache_directory, exist_ok=True)
-        task_key, data_dict = serialize_funct(
+        task_key, data_dict, _ = serialize_funct(
             fn=my_funct,
             fn_args=None,
             fn_kwargs={"a": 1, "b": 2},
@@ -202,7 +202,7 @@ class TestSharedFunctions(unittest.TestCase):
     def test_execute_function_error(self):
         cache_directory = os.path.abspath("executorlib_cache")
         os.makedirs(cache_directory, exist_ok=True)
-        task_key, data_dict = serialize_funct(
+        task_key, data_dict, _ = serialize_funct(
             fn=get_error,
             fn_args=[],
             fn_kwargs={"a": 1},
@@ -241,7 +241,7 @@ class TestSharedFunctions(unittest.TestCase):
         # or an external scancel) must fail the future instead of leaving it pending forever.
         cache_directory = os.path.abspath("executorlib_cache")
         os.makedirs(cache_directory, exist_ok=True)
-        task_key, data_dict = serialize_funct(fn=my_funct, fn_args=[1], fn_kwargs={"b": 2})
+        task_key, data_dict, _ = serialize_funct(fn=my_funct, fn_args=[1], fn_kwargs={"b": 2})
         future_obj = Future()
         with patch(
             "executorlib.standalone.command_pysqa.pysqa_get_status_of_job",
@@ -270,7 +270,7 @@ class TestSharedFunctions(unittest.TestCase):
         # https://github.com/pyiron/executorlib/issues/1037.
         cache_directory = os.path.abspath("executorlib_cache")
         os.makedirs(cache_directory, exist_ok=True)
-        task_key, data_dict = serialize_funct(fn=my_funct, fn_args=[1], fn_kwargs={"b": 2})
+        task_key, data_dict, _ = serialize_funct(fn=my_funct, fn_args=[1], fn_kwargs={"b": 2})
         future_obj = Future()
         with patch(
             "executorlib.standalone.command_pysqa.pysqa_get_status_of_job",
@@ -293,7 +293,7 @@ class TestSharedFunctions(unittest.TestCase):
     def test_check_task_output_job_still_running(self):
         cache_directory = os.path.abspath("executorlib_cache")
         os.makedirs(cache_directory, exist_ok=True)
-        task_key, data_dict = serialize_funct(fn=my_funct, fn_args=[1], fn_kwargs={"b": 2})
+        task_key, data_dict, _ = serialize_funct(fn=my_funct, fn_args=[1], fn_kwargs={"b": 2})
         future_obj = Future()
         with patch(
             "executorlib.standalone.command_pysqa.pysqa_get_status_of_job",
@@ -314,7 +314,7 @@ class TestSharedFunctions(unittest.TestCase):
     def test_check_task_output_status_check_is_throttled(self):
         cache_directory = os.path.abspath("executorlib_cache")
         os.makedirs(cache_directory, exist_ok=True)
-        task_key, data_dict = serialize_funct(fn=my_funct, fn_args=[1], fn_kwargs={"b": 2})
+        task_key, data_dict, _ = serialize_funct(fn=my_funct, fn_args=[1], fn_kwargs={"b": 2})
         status_check_dict = {}
         with patch(
             "executorlib.standalone.command_pysqa.pysqa_get_status_of_job",
@@ -337,7 +337,7 @@ class TestSharedFunctions(unittest.TestCase):
         # subprocess-backed tasks (backend=None) must never trigger a queuing system status check.
         cache_directory = os.path.abspath("executorlib_cache")
         os.makedirs(cache_directory, exist_ok=True)
-        task_key, data_dict = serialize_funct(fn=my_funct, fn_args=[1], fn_kwargs={"b": 2})
+        task_key, data_dict, _ = serialize_funct(fn=my_funct, fn_args=[1], fn_kwargs={"b": 2})
         future_obj = Future()
         with patch(
             "executorlib.standalone.command_pysqa.pysqa_get_status_of_job",

--- a/tests/unit/task_scheduler/file/test_serial.py
+++ b/tests/unit/task_scheduler/file/test_serial.py
@@ -54,6 +54,18 @@ class TestCacheExecutorSerial(unittest.TestCase):
             self.assertEqual(fs1.result(), 3)
             self.assertTrue(fs1.done())
 
+    def test_submit_unpicklable_argument_with_custom_cache_key(self):
+        with FileTaskScheduler(execute_function=subprocess_execute) as exe:
+            fs_bad = exe.submit(
+                len,
+                [Unpicklable()],
+                resource_dict={"cache_key": "bad/key"},
+            )
+            fs_good = exe.submit(my_funct, 1, b=2)
+            with self.assertRaises(TypeError):
+                fs_bad.result(timeout=15)
+            self.assertEqual(fs_good.result(timeout=15), 3)
+
     def test_submit_dependency_with_keyword_arg_future(self):
         with FileTaskScheduler(execute_function=subprocess_execute) as exe:
             fs1 = exe.submit(my_funct, 1, b=2)
@@ -261,6 +273,46 @@ class TestCacheExecutorSerial(unittest.TestCase):
                 "kwargs": {},
                 "future": fs_bad,
                 "resource_dict": {},
+            }
+        )
+        q.put(
+            {
+                "fn": my_funct,
+                "args": (),
+                "kwargs": {"a": 1, "b": 2},
+                "future": fs_good,
+                "resource_dict": {},
+            }
+        )
+        cache_dir = os.path.abspath("executorlib_cache")
+        os.makedirs(cache_dir, exist_ok=True)
+        process = Thread(
+            target=execute_tasks_h5,
+            kwargs={
+                "future_queue": q,
+                "execute_function": subprocess_execute,
+                "executor_kwargs": {"cores": 1, "cwd": None, "cache_directory": cache_dir},
+                "terminate_function": subprocess_terminate,
+            },
+        )
+        process.start()
+        with self.assertRaises(TypeError):
+            fs_bad.result(timeout=15)
+        self.assertEqual(fs_good.result(timeout=15), 3)
+        q.put({"shutdown": True, "wait": True})
+        process.join()
+
+    def test_executor_function_unpicklable_argument_with_cache_key(self):
+        fs_bad = Future()
+        fs_good = Future()
+        q = Queue()
+        q.put(
+            {
+                "fn": len,
+                "args": ([Unpicklable()],),
+                "kwargs": {},
+                "future": fs_bad,
+                "resource_dict": {"cache_key": "bad/key"},
             }
         )
         q.put(

--- a/tests/unit/task_scheduler/file/test_serial.py
+++ b/tests/unit/task_scheduler/file/test_serial.py
@@ -31,6 +31,11 @@ def get_error(a):
     raise ValueError(a)
 
 
+class Unpicklable:
+    def __reduce__(self):
+        raise TypeError("cannot pickle Unpicklable")
+
+
 @unittest.skipIf(
     skip_h5py_test, "h5py is not installed, so the h5py tests are skipped."
 )
@@ -244,6 +249,46 @@ class TestCacheExecutorSerial(unittest.TestCase):
                 command=[],
                 backend="flux",
             )
+
+    def test_executor_function_unpicklable_argument(self):
+        fs_bad = Future()
+        fs_good = Future()
+        q = Queue()
+        q.put(
+            {
+                "fn": len,
+                "args": ([Unpicklable()],),
+                "kwargs": {},
+                "future": fs_bad,
+                "resource_dict": {},
+            }
+        )
+        q.put(
+            {
+                "fn": my_funct,
+                "args": (),
+                "kwargs": {"a": 1, "b": 2},
+                "future": fs_good,
+                "resource_dict": {},
+            }
+        )
+        cache_dir = os.path.abspath("executorlib_cache")
+        os.makedirs(cache_dir, exist_ok=True)
+        process = Thread(
+            target=execute_tasks_h5,
+            kwargs={
+                "future_queue": q,
+                "execute_function": subprocess_execute,
+                "executor_kwargs": {"cores": 1, "cwd": None, "cache_directory": cache_dir},
+                "terminate_function": subprocess_terminate,
+            },
+        )
+        process.start()
+        with self.assertRaises(TypeError):
+            fs_bad.result(timeout=15)
+        self.assertEqual(fs_good.result(timeout=15), 3)
+        q.put({"shutdown": True, "wait": True})
+        process.join()
 
     def test_convert_args_and_kwargs(self):
         f1 = Future()

--- a/tests/unit/task_scheduler/interactive/test_shared.py
+++ b/tests/unit/task_scheduler/interactive/test_shared.py
@@ -20,6 +20,11 @@ def get_error():
     raise ExecutorlibSocketError()
 
 
+class Unpicklable:
+    def __reduce__(self):
+        raise TypeError("cannot pickle Unpicklable")
+
+
 class TestExecuteTaskDictWithoutCache(unittest.TestCase):
     def test_execute_task_sum(self):
         cloudpickle_register(ind=1)
@@ -101,6 +106,34 @@ class TestExecuteTaskDictWithoutCache(unittest.TestCase):
         )
         self.assertFalse(result)
         self.assertFalse(f.done())
+
+    def test_execute_task_unpicklable_argument(self):
+        cloudpickle_register(ind=1)
+        f = Future()
+        interface = interface_bootup(
+            command_lst=get_interactive_execute_command(
+                cores=1,
+            ),
+            connections=SubprocessSpawner(),
+            hostname_localhost=True,
+            log_obj_size=False,
+            worker_id=1,
+            stop_function=None,
+        )
+        self.assertTrue(interface.status)
+        self.assertFalse(f.done())
+        result = execute_task_dict(
+            task_dict={"fn": len, "args": ([Unpicklable()],), "kwargs": {}},
+            future_obj=f,
+            interface=interface,
+            cache_directory=None,
+            cache_key=None,
+            error_log_file=None,
+        )
+        self.assertTrue(result)
+        self.assertTrue(f.done())
+        with self.assertRaises(TypeError):
+            f.result()
 
 
 @unittest.skipIf(

--- a/tests/unit/task_scheduler/interactive/test_shared.py
+++ b/tests/unit/task_scheduler/interactive/test_shared.py
@@ -223,3 +223,44 @@ class TestExecuteTaskDictWithCache(unittest.TestCase):
         )
         self.assertFalse(result)
         self.assertFalse(f.done())
+
+    def test_execute_task_unpicklable_argument_with_cache_key(self):
+        cloudpickle_register(ind=1)
+        bad_future = Future()
+        good_future = Future()
+        interface = interface_bootup(
+            command_lst=get_interactive_execute_command(
+                cores=1,
+            ),
+            connections=SubprocessSpawner(),
+            hostname_localhost=True,
+            log_obj_size=False,
+            worker_id=1,
+            stop_function=None,
+        )
+        self.assertTrue(interface.status)
+
+        bad_result = execute_task_dict(
+            task_dict={"fn": len, "args": ([Unpicklable()],), "kwargs": {}},
+            future_obj=bad_future,
+            interface=interface,
+            cache_directory="cache_execute_task",
+            cache_key="cache/key",
+            error_log_file=None,
+        )
+        self.assertTrue(bad_result)
+        self.assertTrue(bad_future.done())
+        with self.assertRaises(TypeError):
+            bad_future.result()
+
+        good_result = execute_task_dict(
+            task_dict={"fn": sum, "args": ([1, 2],), "kwargs": {}},
+            future_obj=good_future,
+            interface=interface,
+            cache_directory="cache_execute_task",
+            cache_key="cache/key-next",
+            error_log_file=None,
+        )
+        self.assertTrue(good_result)
+        self.assertTrue(good_future.done())
+        self.assertEqual(good_future.result(), 3)


### PR DESCRIPTION
## Summary
- Fixes #1057: an argument passed to `Executor.submit()` that cloudpickle cannot serialize currently raises inside the background scheduler thread, killing it — the submitted future is never resolved, so `future.result()`, `shutdown()`, and the `with`-block exit all hang forever, and every other pending future on the same executor is orphaned.
- Wraps the per-task dispatch in both the interactive backend (`task_scheduler/interactive/shared.py::execute_task_dict`) and the file backend (`task_scheduler/file/shared.py::execute_tasks_h5`) in `try/except Exception`, routing the exception to `task_dict["future"].set_exception(e)` so the failure surfaces on the affected future while the scheduler thread keeps serving the rest of the queue.
- This implements fix (1) from the issue's "Expected behaviour" section, following the sketch verified by @pmrv in the issue comments.

## Test plan
- [x] Added `test_execute_task_unpicklable_argument` to `tests/unit/task_scheduler/interactive/test_shared.py`, reproducing the interactive-backend hang and confirming `future.result()` now raises `TypeError` instead.
- [x] Added `test_executor_function_unpicklable_argument` to `tests/unit/task_scheduler/file/test_serial.py`, reproducing the file-backend hang and confirming a subsequent healthy task on the same scheduler thread still completes.
- [x] Added `test_unpicklable_argument_block_allocation_false`, `test_unpicklable_argument_block_allocation_true`, and `test_unpicklable_argument_recovers_for_next_task` to `tests/unit/executor/test_single_dependencies.py`, matching the `SingleNodeExecutor` reproduction from the issue for both one-to-one and block-allocation modes.
- [x] Verified each new unit test fails (thread dies / hangs) against the pre-fix code and passes after the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Task serialization failures are now reported through the task’s future, allowing callers to receive the underlying error.
  * Tasks with unpicklable arguments fail cleanly without preventing subsequent tasks from completing.
  * Improved handling of communication failures during file-based and interactive task execution, including cached task runs.

* **Tests**
  * Added coverage for serialization failures, unpicklable arguments, cache handling, and continued task processing across supported execution modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->