### PR TITLE
Fix KeyError in SocketInterface.shutdown() when worker exits during wait

### DIFF
--- a/src/executorlib/standalone/interactive/communication.py
+++ b/src/executorlib/standalone/interactive/communication.py
@@ -150,9 +150,11 @@ class SocketInterface:
         """
         result = None
         if self._spawner.poll():
-            result = self.send_and_receive_dict(
+            output = self.send_and_receive_dict(
                 input_dict={"shutdown": True, "wait": wait}
-            )["result"]
+            )
+            if "result" in output:
+                result = output["result"]
             self._spawner.shutdown(wait=wait)
         self._reset_socket()
         return result

--- a/tests/unit/standalone/interactive/test_communication.py
+++ b/tests/unit/standalone/interactive/test_communication.py
@@ -167,8 +167,16 @@ class TestInterface(unittest.TestCase):
             log_obj_size=False,
             time_out_ms=100,
         )
-        interface.bind_to_random_port()
-        self.assertIsNone(interface.shutdown(wait=True))
+        port = interface.bind_to_random_port()
+        # Connect a peer so the PAIR socket is not in the ZMQ "mute state" and
+        # send_dict() does not block forever. The peer never replies, emulating
+        # a worker process that exits while shutdown() is waiting for its reply.
+        context, socket = interface_connect(host="localhost", port=str(port))
+        try:
+            self.assertIsNone(interface.shutdown(wait=True))
+        finally:
+            socket.close()
+            context.term()
 
     def test_interface_serial_wrong_input(self):
         cloudpickle_register(ind=1)

--- a/tests/unit/standalone/interactive/test_communication.py
+++ b/tests/unit/standalone/interactive/test_communication.py
@@ -31,6 +31,20 @@ class BrokenSpawner(MpiExecSpawner):
     def bootup(self, command_lst: list[str], stop_function: Optional[Callable] = None,):
         return False
 
+
+class DelayedExitSpawner(MpiExecSpawner):
+    """Spawner that reports the process as alive for the first poll() call only,
+    emulating a worker which exits while shutdown() is waiting for its reply."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._poll_call_count = 0
+
+    def poll(self) -> bool:
+        self._poll_call_count += 1
+        return self._poll_call_count == 1
+
+
 class TestInterface(unittest.TestCase):
     @unittest.skipIf(
         skip_mpi4py_test, "mpi4py is not installed, so the mpi4py tests are skipped."
@@ -145,6 +159,16 @@ class TestInterface(unittest.TestCase):
             sleep(0.1)
         self.assertFalse(interface._spawner.poll())
         interface.shutdown(wait=True)
+
+    def test_interface_shutdown_with_process_exiting_during_wait(self):
+        cloudpickle_register(ind=1)
+        interface = SocketInterface(
+            spawner=DelayedExitSpawner(cwd=None, cores=1, openmpi_oversubscribe=False),
+            log_obj_size=False,
+            time_out_ms=100,
+        )
+        interface.bind_to_random_port()
+        self.assertIsNone(interface.shutdown(wait=True))
 
     def test_interface_serial_wrong_input(self):
         cloudpickle_register(ind=1)


### PR DESCRIPTION
## Summary
- `SocketInterface.shutdown()` unconditionally indexed the reply dict returned by `send_and_receive_dict()` with `["result"]`.
- `receive_dict()` can instead return `{"error": ExecutorlibSocketError(...)}` if the worker process exits while `shutdown()` is waiting for its reply (a benign race - the worker simply finished/exited on its own).
- That race raised a `KeyError: 'result'` inside `SocketInterface.__del__`, which Python cannot propagate from a destructor, so it prints a confusing `Exception ignored in: <function SocketInterface.__del__>` traceback during garbage collection (e.g. when Jupyter releases old cached objects) even though nothing actually crashed.
- Fix: only read the `"result"` key when it's present, otherwise `shutdown()` returns `None` for this benign race instead of raising.

## Test plan
- [x] Added `test_interface_shutdown_with_process_exiting_during_wait`, which uses a spawner whose `poll()` reports the process alive only once (matching the real race window) and asserts `shutdown()` no longer raises.
- [ ] Full test suite run pending (this environment's MPI/network setup makes the broader suite slow to run interactively).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved shutdown handling when a worker exits while the interface is waiting for a response.
  - Shutdown now completes reliably when the worker’s response does not include a result.
  - Ensured shutdown returns the expected empty result and properly resets the connection state.
  - Prevented shutdown waits from leaving the communication interface in an inconsistent state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->